### PR TITLE
Cleanup 2, types, build script, docker, maintainability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-    deploy:
-      resources:
-        limits:
-          memory: 6G
-        reservations:
-          memory: 4G
 
 volumes:
   postgres_data:

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --port 3000",
-		"build": "next build",
+		"build": "set NODE_OPTIONS=--max-old-space-size=8192 && next build",
 		"start": "next start",
 		"lint": "next lint",
-		"vercel-build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 prisma generate && prisma migrate deploy && next build",
+		"vercel-build": "prisma generate && prisma migrate deploy && next build",
 		"postinstall": "prisma generate",
 		"import-production-contacts": "tsx --tsconfig tsconfig.json scripts/import-production-contacts.ts",
 		"check-elasticsearch": "tsx --tsconfig tsconfig.json scripts/check-elasticsearch.tsx",

--- a/src/app/api/_utils/openai.tsx
+++ b/src/app/api/_utils/openai.tsx
@@ -1,55 +1,38 @@
-// kept for potential reuse
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const withTimeout = async <T,>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
-    return new Promise<T>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error('OpenAI request timed out')), timeoutMs);
-        promise
-            .then((value) => {
-                clearTimeout(timer);
-                resolve(value);
-            })
-            .catch((err) => {
-                clearTimeout(timer);
-                reject(err);
-            });
-    });
-};
-
 export const fetchOpenAi = async (
-    model: string,
-    prompt: string,
-    content: string
+	model: string,
+	prompt: string,
+	content: string
 ): Promise<string> => {
-    const controller = new AbortController();
-    const timeoutMs = 12000; // 12s hard limit for location parse to avoid UI hangs
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-        const response = await fetch('https://api.openai.com/v1/chat/completions', {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${process.env.OPEN_AI_API_KEY}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                model,
-                messages: [
-                    { role: 'system', content: prompt },
-                    {
-                        role: 'user',
-                        content,
-                    },
-                ],
-            }),
-            signal: controller.signal,
-        });
+	const controller = new AbortController();
+	const timeoutMs = 12000; // 12s hard limit for location parse to avoid UI hangs
+	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const response = await fetch('https://api.openai.com/v1/chat/completions', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${process.env.OPEN_AI_API_KEY}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				model,
+				messages: [
+					{ role: 'system', content: prompt },
+					{
+						role: 'user',
+						content,
+					},
+				],
+			}),
+			signal: controller.signal,
+		});
 
-        const res = await response.json();
+		const res = await response.json();
 
-        if (!response.ok) {
-            throw new Error(res.error?.message || 'Open AI request failed');
-        }
-        return res.choices[0].message.content;
-    } finally {
-        clearTimeout(timeoutId);
-    }
+		if (!response.ok) {
+			throw new Error(res.error?.message || 'Open AI request failed');
+		}
+		return res.choices[0].message.content;
+	} finally {
+		clearTimeout(timeoutId);
+	}
 };

--- a/src/app/api/_utils/postTraining.ts
+++ b/src/app/api/_utils/postTraining.ts
@@ -1,21 +1,22 @@
+import { normalizeTextCaseAndWhitespace } from '@/utils';
 import { fetchOpenAi } from './openai';
 import { OPEN_AI_MODEL_OPTIONS } from '@/constants';
 
 export type PostTrainingProfile = {
-  active: boolean;
-  excludeTerms: string[];
-  demoteTerms: string[];
-  strictExclude?: boolean;
-  requirePositive?: boolean;
-  includeCompanyTerms?: string[];
-  includeTitleTerms?: string[];
-  includeWebsiteTerms?: string[];
-  includeIndustryTerms?: string[];
-  // Auxiliary, lower-priority inclusion terms used to fill tail (e.g., bars/restaurants)
-  auxCompanyTerms?: string[];
-  auxTitleTerms?: string[];
-  auxWebsiteTerms?: string[];
-  auxIndustryTerms?: string[];
+	active: boolean;
+	excludeTerms: string[];
+	demoteTerms: string[];
+	strictExclude?: boolean;
+	requirePositive?: boolean;
+	includeCompanyTerms?: string[];
+	includeTitleTerms?: string[];
+	includeWebsiteTerms?: string[];
+	includeIndustryTerms?: string[];
+	// Auxiliary, lower-priority inclusion terms used to fill tail (e.g., bars/restaurants)
+	auxCompanyTerms?: string[];
+	auxTitleTerms?: string[];
+	auxWebsiteTerms?: string[];
+	auxIndustryTerms?: string[];
 };
 
 // Cache for LLM responses to avoid repeated API calls for the same query
@@ -25,23 +26,19 @@ const filterCache = new Map<string, PostTrainingProfile>();
 const queryTypeCache = new Map<string, string>(); // Cache for query type classification
 const MAX_CACHE_SIZE = 100; // Prevent unbounded memory growth
 
-function normalize(text: string): string {
-  return text.trim().toLowerCase();
-}
-
 /**
  * Clear the filter cache - useful for testing or when filters need refreshing
  */
 export function clearFilterCache(): void {
-  filterCache.clear();
-  queryTypeCache.clear();
+	filterCache.clear();
+	queryTypeCache.clear();
 }
 
 /**
  * Get current cache size for monitoring
  */
 export function getFilterCacheSize(): number {
-  return filterCache.size;
+	return filterCache.size;
 }
 
 /**
@@ -49,14 +46,14 @@ export function getFilterCacheSize(): number {
  * This replaces hardcoded pattern matching with intelligent understanding
  */
 async function classifyQueryType(query: string): Promise<string> {
-  const normalizedQuery = normalize(query);
-  
-  // Check cache first
-  if (queryTypeCache.has(normalizedQuery)) {
-    return queryTypeCache.get(normalizedQuery)!;
-  }
+	const normalizedQuery = normalizeTextCaseAndWhitespace(query);
 
-  const prompt = `You are an expert at understanding search queries and classifying them into categories. Analyze the following query and determine its type.
+	// Check cache first
+	if (queryTypeCache.has(normalizedQuery)) {
+		return queryTypeCache.get(normalizedQuery)!;
+	}
+
+	const prompt = `You are an expert at understanding search queries and classifying them into categories. Analyze the following query and determine its type.
 
 Query: "${query}"
 
@@ -75,106 +72,120 @@ Consider synonyms and related terms. For example:
 
 Return ONLY the category name (e.g., "music_venue"), nothing else.`;
 
-  try {
-    const response = await fetchOpenAi(
-      OPEN_AI_MODEL_OPTIONS.o4mini,
-      prompt,
-      `Classify this search query: "${query}"`
-    );
+	try {
+		const response = await fetchOpenAi(
+			OPEN_AI_MODEL_OPTIONS.o4mini,
+			prompt,
+			`Classify this search query: "${query}"`
+		);
 
-    const queryType = response.trim().toLowerCase().replace(/['"]/g, '');
-    
-    // Validate the response is one of our expected types
-    const validTypes = ['music_venue', 'wedding_planner', 'event_planner', 'photographer', 'catering', 'general'];
-    const finalType = validTypes.includes(queryType) ? queryType : 'general';
-    
-    // Cache the result with size limit
-    if (queryTypeCache.size >= MAX_CACHE_SIZE) {
-      const firstKey = queryTypeCache.keys().next().value;
-      if (firstKey) queryTypeCache.delete(firstKey);
-    }
-    queryTypeCache.set(normalizedQuery, finalType);
-    
-    return finalType;
-  } catch (error) {
-    console.error('Error classifying query type with LLM:', error);
-    
-    // Fallback to basic pattern matching if LLM fails
-    if (normalizedQuery.includes('venue') || normalizedQuery.includes('music') || 
-        normalizedQuery.includes('concert') || normalizedQuery.includes('theater')) {
-      return 'music_venue';
-    }
-    if (normalizedQuery.includes('wedding')) {
-      return 'wedding_planner';
-    }
-    if (normalizedQuery.includes('event') || normalizedQuery.includes('party')) {
-      return 'event_planner';
-    }
-    if (normalizedQuery.includes('photo')) {
-      return 'photographer';
-    }
-    if (normalizedQuery.includes('cater') || normalizedQuery.includes('food service')) {
-      return 'catering';
-    }
-    
-    return 'general';
-  }
+		const queryType = response.trim().toLowerCase().replace(/['"]/g, '');
+
+		// Validate the response is one of our expected types
+		const validTypes = [
+			'music_venue',
+			'wedding_planner',
+			'event_planner',
+			'photographer',
+			'catering',
+			'general',
+		];
+		const finalType = validTypes.includes(queryType) ? queryType : 'general';
+
+		// Cache the result with size limit
+		if (queryTypeCache.size >= MAX_CACHE_SIZE) {
+			const firstKey = queryTypeCache.keys().next().value;
+			if (firstKey) queryTypeCache.delete(firstKey);
+		}
+		queryTypeCache.set(normalizedQuery, finalType);
+
+		return finalType;
+	} catch (error) {
+		console.error('Error classifying query type with LLM:', error);
+
+		// Fallback to basic pattern matching if LLM fails
+		if (
+			normalizedQuery.includes('venue') ||
+			normalizedQuery.includes('music') ||
+			normalizedQuery.includes('concert') ||
+			normalizedQuery.includes('theater')
+		) {
+			return 'music_venue';
+		}
+		if (normalizedQuery.includes('wedding')) {
+			return 'wedding_planner';
+		}
+		if (normalizedQuery.includes('event') || normalizedQuery.includes('party')) {
+			return 'event_planner';
+		}
+		if (normalizedQuery.includes('photo')) {
+			return 'photographer';
+		}
+		if (normalizedQuery.includes('cater') || normalizedQuery.includes('food service')) {
+			return 'catering';
+		}
+
+		return 'general';
+	}
 }
 
 /**
  * Generate filter terms using OpenAI based on the query context
  * This replaces hardcoded lists with dynamic, context-aware filtering
  */
-async function generateFiltersWithLLM(query: string, queryType: string): Promise<PostTrainingProfile> {
-  const cacheKey = `${queryType}:${query}`;
-  
-  // Check cache first
-  if (filterCache.has(cacheKey)) {
-    return filterCache.get(cacheKey)!;
-  }
+async function generateFiltersWithLLM(
+	query: string,
+	queryType: string
+): Promise<PostTrainingProfile> {
+	const cacheKey = `${queryType}:${query}`;
 
-  // Build context-specific guidelines
-  let contextGuidelines = '';
-  switch (queryType) {
-    case 'music_venue':
-      contextGuidelines = `
+	// Check cache first
+	if (filterCache.has(cacheKey)) {
+		return filterCache.get(cacheKey)!;
+	}
+
+	// Build context-specific guidelines
+	let contextGuidelines = '';
+	switch (queryType) {
+		case 'music_venue':
+			contextGuidelines = `
 - Exclude: educational institutions (universities, colleges, conservatories), unrelated C-suite titles, academic faculty, legal professions, individual musicians/bands
 - Include: performance venues, concert halls, theaters, entertainment spaces, live music venues, clubs
 - Auxiliary (lower priority): bars, restaurants, nightclubs that might host live music
 - Focus on venue management, booking, and production roles`;
-      break;
-    case 'wedding_planner':
-      contextGuidelines = `
+			break;
+		case 'wedding_planner':
+			contextGuidelines = `
 - Exclude: directory/aggregator sites (WeddingWire, The Knot, etc.), venues without planning services
 - Include: individual planners, planning companies, wedding coordinators, bridal consultants
 - Focus on actual service providers, not marketplaces`;
-      break;
-    case 'event_planner':
-      contextGuidelines = `
+			break;
+		case 'event_planner':
+			contextGuidelines = `
 - Exclude: venues without planning services, directory sites
 - Include: event planning companies, party planners, corporate event organizers, meeting planners
 - Focus on planning and coordination services`;
-      break;
-    case 'photographer':
-      contextGuidelines = `
+			break;
+		case 'photographer':
+			contextGuidelines = `
 - Exclude: stock photo sites, photo printing services only
 - Include: professional photographers, photography studios, photo services
 - Focus on actual photographers and studios`;
-      break;
-    case 'catering':
-      contextGuidelines = `
+			break;
+		case 'catering':
+			contextGuidelines = `
 - Exclude: restaurants without catering services, grocery stores
 - Include: catering companies, food service providers, event caterers
 - Focus on businesses that specifically offer catering services`;
-      break;
-    default:
-      contextGuidelines = `
+			break;
+		default:
+			contextGuidelines = `
 - Analyze the query intent and generate relevant filters
 - Exclude irrelevant or spam-like results
 - Include terms that match the service or role being searched`;
-  }
+	}
 
-  const prompt = `You are an expert at understanding search queries and generating appropriate filters for contact searches. Based on the query type and context, generate relevant filter terms.
+	const prompt = `You are an expert at understanding search queries and generating appropriate filters for contact searches. Based on the query type and context, generate relevant filter terms.
 
 Query Type: ${queryType}
 Query: ${query}
@@ -202,299 +213,319 @@ General Guidelines:
 - Think about what would be irrelevant noise vs helpful results
 - Include plural forms and common misspellings where appropriate`;
 
-  try {
-    const response = await fetchOpenAi(
-      OPEN_AI_MODEL_OPTIONS.o4mini,
-      prompt,
-      `Generate appropriate filter terms for this ${queryType} search query: "${query}"`
-    );
+	try {
+		const response = await fetchOpenAi(
+			OPEN_AI_MODEL_OPTIONS.o4mini,
+			prompt,
+			`Generate appropriate filter terms for this ${queryType} search query: "${query}"`
+		);
 
-    // Clean the response to ensure it's valid JSON
-    const cleanedResponse = response.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-    const filters = JSON.parse(cleanedResponse);
-    
-    const profile: PostTrainingProfile = {
-      active: true,
-      excludeTerms: filters.excludeTerms || [],
-      demoteTerms: filters.demoteTerms || [],
-      strictExclude: true,
-      requirePositive: queryType === 'music_venue',
-      includeCompanyTerms: filters.includeCompanyTerms || [],
-      includeTitleTerms: filters.includeTitleTerms || [],
-      includeWebsiteTerms: filters.includeWebsiteTerms || [],
-      includeIndustryTerms: filters.includeIndustryTerms || [],
-      auxCompanyTerms: filters.auxCompanyTerms || [],
-      auxTitleTerms: filters.auxTitleTerms || [],
-      auxWebsiteTerms: filters.auxWebsiteTerms || [],
-      auxIndustryTerms: filters.auxIndustryTerms || [],
-    };
+		// Clean the response to ensure it's valid JSON
+		const cleanedResponse = response
+			.replace(/```json\n?/g, '')
+			.replace(/```\n?/g, '')
+			.trim();
+		const filters = JSON.parse(cleanedResponse);
 
-    // Cache the result with size limit
-    if (filterCache.size >= MAX_CACHE_SIZE) {
-      // Simple FIFO eviction - remove the oldest entry
-      const firstKey = filterCache.keys().next().value;
-      if (firstKey) filterCache.delete(firstKey);
-    }
-    filterCache.set(cacheKey, profile);
-    
-    return profile;
-    } catch (error) {
-    console.error('Error generating filters with LLM:', error);
-    
-    // Return a more intelligent fallback based on query type
-    switch (queryType) {
-      case 'music_venue':
-        return {
-          active: true,
-          excludeTerms: ['university', 'college', 'school', 'faculty', 'professor'],
-          demoteTerms: ['campus', 'department'],
-          strictExclude: true,
-          requirePositive: true,
-          includeCompanyTerms: ['venue', 'theater', 'theatre', 'hall', 'arena', 'club'],
-          includeTitleTerms: ['booking', 'manager', 'promoter', 'talent buyer'],
-          includeWebsiteTerms: ['tickets', 'events', 'concerts', 'shows'],
-          includeIndustryTerms: ['entertainment', 'music', 'performing arts'],
-          auxCompanyTerms: ['bar', 'restaurant', 'lounge'],
-          auxTitleTerms: [],
-          auxWebsiteTerms: [],
-          auxIndustryTerms: []
-        };
-      case 'wedding_planner':
-        return {
-          active: true,
-          excludeTerms: ['weddingwire', 'theknot', 'wedding.com'],
-          demoteTerms: [],
-          strictExclude: true,
-          requirePositive: false,
-          includeCompanyTerms: ['wedding', 'bridal'],
-          includeTitleTerms: ['planner', 'coordinator', 'consultant'],
-          includeWebsiteTerms: [],
-          includeIndustryTerms: ['wedding', 'events']
-        };
-      case 'event_planner':
-        return {
-          active: true,
-          excludeTerms: [],
-          demoteTerms: [],
-          strictExclude: false,
-          requirePositive: false,
-          includeCompanyTerms: ['event', 'planning'],
-          includeTitleTerms: ['planner', 'coordinator', 'organizer'],
-          includeWebsiteTerms: [],
-          includeIndustryTerms: ['events', 'planning']
-        };
-      case 'photographer':
-        return {
-          active: true,
-          excludeTerms: ['shutterstock', 'getty', 'stock'],
-          demoteTerms: [],
-          strictExclude: false,
-          requirePositive: false,
-          includeCompanyTerms: ['photography', 'photo', 'studio'],
-          includeTitleTerms: ['photographer'],
-          includeWebsiteTerms: [],
-          includeIndustryTerms: ['photography']
-        };
-      case 'catering':
-        return {
-          active: true,
-          excludeTerms: [],
-          demoteTerms: [],
-          strictExclude: false,
-          requirePositive: false,
-          includeCompanyTerms: ['catering', 'caterer'],
-          includeTitleTerms: ['caterer', 'chef'],
-          includeWebsiteTerms: [],
-          includeIndustryTerms: ['catering', 'food service']
-        };
-      default:
-        // Default fallback
-        return {
-          active: false,
-          excludeTerms: [],
-          demoteTerms: []
-        };
-    }
-  }
+		const profile: PostTrainingProfile = {
+			active: true,
+			excludeTerms: filters.excludeTerms || [],
+			demoteTerms: filters.demoteTerms || [],
+			strictExclude: true,
+			requirePositive: queryType === 'music_venue',
+			includeCompanyTerms: filters.includeCompanyTerms || [],
+			includeTitleTerms: filters.includeTitleTerms || [],
+			includeWebsiteTerms: filters.includeWebsiteTerms || [],
+			includeIndustryTerms: filters.includeIndustryTerms || [],
+			auxCompanyTerms: filters.auxCompanyTerms || [],
+			auxTitleTerms: filters.auxTitleTerms || [],
+			auxWebsiteTerms: filters.auxWebsiteTerms || [],
+			auxIndustryTerms: filters.auxIndustryTerms || [],
+		};
+
+		// Cache the result with size limit
+		if (filterCache.size >= MAX_CACHE_SIZE) {
+			// Simple FIFO eviction - remove the oldest entry
+			const firstKey = filterCache.keys().next().value;
+			if (firstKey) filterCache.delete(firstKey);
+		}
+		filterCache.set(cacheKey, profile);
+
+		return profile;
+	} catch (error) {
+		console.error('Error generating filters with LLM:', error);
+
+		// Return a more intelligent fallback based on query type
+		switch (queryType) {
+			case 'music_venue':
+				return {
+					active: true,
+					excludeTerms: ['university', 'college', 'school', 'faculty', 'professor'],
+					demoteTerms: ['campus', 'department'],
+					strictExclude: true,
+					requirePositive: true,
+					includeCompanyTerms: ['venue', 'theater', 'theatre', 'hall', 'arena', 'club'],
+					includeTitleTerms: ['booking', 'manager', 'promoter', 'talent buyer'],
+					includeWebsiteTerms: ['tickets', 'events', 'concerts', 'shows'],
+					includeIndustryTerms: ['entertainment', 'music', 'performing arts'],
+					auxCompanyTerms: ['bar', 'restaurant', 'lounge'],
+					auxTitleTerms: [],
+					auxWebsiteTerms: [],
+					auxIndustryTerms: [],
+				};
+			case 'wedding_planner':
+				return {
+					active: true,
+					excludeTerms: ['weddingwire', 'theknot', 'wedding.com'],
+					demoteTerms: [],
+					strictExclude: true,
+					requirePositive: false,
+					includeCompanyTerms: ['wedding', 'bridal'],
+					includeTitleTerms: ['planner', 'coordinator', 'consultant'],
+					includeWebsiteTerms: [],
+					includeIndustryTerms: ['wedding', 'events'],
+				};
+			case 'event_planner':
+				return {
+					active: true,
+					excludeTerms: [],
+					demoteTerms: [],
+					strictExclude: false,
+					requirePositive: false,
+					includeCompanyTerms: ['event', 'planning'],
+					includeTitleTerms: ['planner', 'coordinator', 'organizer'],
+					includeWebsiteTerms: [],
+					includeIndustryTerms: ['events', 'planning'],
+				};
+			case 'photographer':
+				return {
+					active: true,
+					excludeTerms: ['shutterstock', 'getty', 'stock'],
+					demoteTerms: [],
+					strictExclude: false,
+					requirePositive: false,
+					includeCompanyTerms: ['photography', 'photo', 'studio'],
+					includeTitleTerms: ['photographer'],
+					includeWebsiteTerms: [],
+					includeIndustryTerms: ['photography'],
+				};
+			case 'catering':
+				return {
+					active: true,
+					excludeTerms: [],
+					demoteTerms: [],
+					strictExclude: false,
+					requirePositive: false,
+					includeCompanyTerms: ['catering', 'caterer'],
+					includeTitleTerms: ['caterer', 'chef'],
+					includeWebsiteTerms: [],
+					includeIndustryTerms: ['catering', 'food service'],
+				};
+			default:
+				// Default fallback
+				return {
+					active: false,
+					excludeTerms: [],
+					demoteTerms: [],
+				};
+		}
+	}
 }
 
 /**
  * Main entry point for getting post-training filters based on a search query.
- * 
+ *
  * This function now uses LLM to intelligently understand query intent and synonyms.
  * For example, all of these will be recognized as music venue searches:
  * - "music venue"
- * - "concert hall" 
+ * - "concert hall"
  * - "live music"
  * - "performance space"
  * - "theater"
  * - "venue"
  * - "amphitheater"
  * - "club with bands"
- * 
+ *
  * The LLM classification ensures we catch all variations without hardcoding every possibility.
- * 
+ *
  * @param rawQuery - The search query from the user
  * @returns PostTrainingProfile with appropriate filters for the query type
  */
-export async function getPostTrainingForQuery(rawQuery: string): Promise<PostTrainingProfile> {
-  try {
-    // Skip LLM if no API key
-    if (!process.env.OPEN_AI_API_KEY) {
-      return getFallbackPostTraining(rawQuery);
-    }
-    
-    // Use LLM to intelligently classify the query type
-    const queryType = await classifyQueryType(rawQuery);
-    
-    // If it's a general query with no specific filtering needs, return inactive profile
-    if (queryType === 'general') {
-      // Still check if the query might benefit from filtering
-      const q = normalize(rawQuery);
-      const mightNeedFiltering = q.includes('service') || 
-                                 q.includes('provider') ||
-                                 q.includes('consultant') ||
-                                 q.includes('agency') ||
-                                 q.includes('company');
-      
-      if (mightNeedFiltering) {
-        return await generateFiltersWithLLM(rawQuery, 'general');
-      }
-      
-      return { active: false, excludeTerms: [], demoteTerms: [] };
-    }
-    
-    // Generate appropriate filters for the classified query type
-    return await generateFiltersWithLLM(rawQuery, queryType);
-  } catch (error) {
-    console.error('Error in getPostTrainingForQuery, falling back:', error);
-    return getFallbackPostTraining(rawQuery);
-  }
+export async function getPostTrainingForQuery(
+	rawQuery: string
+): Promise<PostTrainingProfile> {
+	try {
+		// Skip LLM if no API key
+		if (!process.env.OPEN_AI_API_KEY) {
+			return getFallbackPostTraining(rawQuery);
+		}
+
+		// Use LLM to intelligently classify the query type
+		const queryType = await classifyQueryType(rawQuery);
+
+		// If it's a general query with no specific filtering needs, return inactive profile
+		if (queryType === 'general') {
+			// Still check if the query might benefit from filtering
+			const q = normalizeTextCaseAndWhitespace(rawQuery);
+			const mightNeedFiltering =
+				q.includes('service') ||
+				q.includes('provider') ||
+				q.includes('consultant') ||
+				q.includes('agency') ||
+				q.includes('company');
+
+			if (mightNeedFiltering) {
+				return await generateFiltersWithLLM(rawQuery, 'general');
+			}
+
+			return { active: false, excludeTerms: [], demoteTerms: [] };
+		}
+
+		// Generate appropriate filters for the classified query type
+		return await generateFiltersWithLLM(rawQuery, queryType);
+	} catch (error) {
+		console.error('Error in getPostTrainingForQuery, falling back:', error);
+		return getFallbackPostTraining(rawQuery);
+	}
 }
 
 // Get the music venue profile with all the exclusions
 function getMusicVenueProfile(): PostTrainingProfile {
-  const excludeTerms = [
-    'university',
-    'university of', 
-    'state university',
-    'community college',
-    'college of',
-    'school of music',
-    'conservatory',
-    'institute of technology',
-    'polytechnic',
-    'CEO',
-    'president',
-    'vice president',
-    'director of sales',
-    'director of marketing',
-    'faculty',
-    'professor',
-    'lawyer',
-    'partner',
-    'law firm',
-    'songwriter',
-    'drummer',
-    'guitarist',
-    'producer',
-    'band',
-    'bandleader'
-  ];
-  
-  const includeCompanyTerms = [
-    'theatre',
-    'theater',
-    'performing arts center',
-    'concert hall',
-    'music hall',
-    'auditorium',
-    'amphitheater',
-    'amphitheatre',
-    'opera house',
-    'pavilion',
-    'arena',
-    'ballroom',
-    'civic center',
-    'playhouse',
-    'house of blues',
-    'fillmore',
-    'music venue',
-    'live music'
-  ];
-  
-  const auxCompanyTerms = [
-    'bar',
-    'pub',
-    'tavern',
-    'lounge',
-    'brewery',
-    'restaurant',
-    'bistro',
-    'cafe',
-    'nightclub',
-    'club',
-    'jazz club',
-    'blues club'
-  ];
-  
-  const includeTitleTerms = [
-    'music venue',
-    'talent buyer',
-    'talent booker',
-    'booker',
-    'booking',
-    'promoter',
-    'venue manager',
-    'general manager',
-    'production manager',
-    'events manager',
-    'event coordinator',
-    'programming director',
-    'entertainment director',
-    'box office',
-    'house manager',
-    'stage manager',
-    'technical director'
-  ];
-  
-  return {
-    active: true,
-    excludeTerms,
-    demoteTerms: ['college', 'univ', 'campus', 'school', 'symphony'],
-    strictExclude: true,
-    requirePositive: true,
-    includeCompanyTerms,
-    includeTitleTerms,
-    includeWebsiteTerms: ['tickets', 'ticketing', 'theatre', 'theater', 'venue', 'concert', 'events', 'calendar', 'live', 'music'],
-    includeIndustryTerms: ['performing arts', 'entertainment', 'music', 'live events'],
-    auxCompanyTerms,
-    auxWebsiteTerms: ['menu', 'reservations', 'happy hour', 'bar', 'restaurant'],
-    auxIndustryTerms: ['hospitality', 'food and beverage', 'restaurants', 'bars']
-  };
+	const excludeTerms = [
+		'university',
+		'university of',
+		'state university',
+		'community college',
+		'college of',
+		'school of music',
+		'conservatory',
+		'institute of technology',
+		'polytechnic',
+		'CEO',
+		'president',
+		'vice president',
+		'director of sales',
+		'director of marketing',
+		'faculty',
+		'professor',
+		'lawyer',
+		'partner',
+		'law firm',
+		'songwriter',
+		'drummer',
+		'guitarist',
+		'producer',
+		'band',
+		'bandleader',
+	];
+
+	const includeCompanyTerms = [
+		'theatre',
+		'theater',
+		'performing arts center',
+		'concert hall',
+		'music hall',
+		'auditorium',
+		'amphitheater',
+		'amphitheatre',
+		'opera house',
+		'pavilion',
+		'arena',
+		'ballroom',
+		'civic center',
+		'playhouse',
+		'house of blues',
+		'fillmore',
+		'music venue',
+		'live music',
+	];
+
+	const auxCompanyTerms = [
+		'bar',
+		'pub',
+		'tavern',
+		'lounge',
+		'brewery',
+		'restaurant',
+		'bistro',
+		'cafe',
+		'nightclub',
+		'club',
+		'jazz club',
+		'blues club',
+	];
+
+	const includeTitleTerms = [
+		'music venue',
+		'talent buyer',
+		'talent booker',
+		'booker',
+		'booking',
+		'promoter',
+		'venue manager',
+		'general manager',
+		'production manager',
+		'events manager',
+		'event coordinator',
+		'programming director',
+		'entertainment director',
+		'box office',
+		'house manager',
+		'stage manager',
+		'technical director',
+	];
+
+	return {
+		active: true,
+		excludeTerms,
+		demoteTerms: ['college', 'univ', 'campus', 'school', 'symphony'],
+		strictExclude: true,
+		requirePositive: true,
+		includeCompanyTerms,
+		includeTitleTerms,
+		includeWebsiteTerms: [
+			'tickets',
+			'ticketing',
+			'theatre',
+			'theater',
+			'venue',
+			'concert',
+			'events',
+			'calendar',
+			'live',
+			'music',
+		],
+		includeIndustryTerms: ['performing arts', 'entertainment', 'music', 'live events'],
+		auxCompanyTerms,
+		auxWebsiteTerms: ['menu', 'reservations', 'happy hour', 'bar', 'restaurant'],
+		auxIndustryTerms: ['hospitality', 'food and beverage', 'restaurants', 'bars'],
+	};
 }
 
 // Synchronous fallback for when LLM is not available
 function getFallbackPostTraining(rawQuery: string): PostTrainingProfile {
-  const q = normalize(rawQuery);
-  
-  // Music venue specific post-training
-  if (q.includes('music venue') || q.includes('music venues') || 
-      q.includes('concert') || q.includes('performance') || q.includes('live music')) {
-    return getMusicVenueProfile();
-  }
-  
-  // Wedding planner specific
-  if (q.includes('wedding planner') || q.includes('wedding planners')) {
-    return {
-      active: true,
-      excludeTerms: ['weddingwire'],
-      demoteTerms: [],
-      strictExclude: true
-    };
-  }
-  
-  return { active: false, excludeTerms: [], demoteTerms: [] };
+	const q = normalizeTextCaseAndWhitespace(rawQuery);
+
+	// Music venue specific post-training
+	if (
+		q.includes('music venue') ||
+		q.includes('music venues') ||
+		q.includes('concert') ||
+		q.includes('performance') ||
+		q.includes('live music')
+	) {
+		return getMusicVenueProfile();
+	}
+
+	// Wedding planner specific
+	if (q.includes('wedding planner') || q.includes('wedding planners')) {
+		return {
+			active: true,
+			excludeTerms: ['weddingwire'],
+			demoteTerms: [],
+			strictExclude: true,
+		};
+	}
+
+	return { active: false, excludeTerms: [], demoteTerms: [] };
 }
-
-

--- a/src/app/api/_utils/searchPreprocess.ts
+++ b/src/app/api/_utils/searchPreprocess.ts
@@ -1,326 +1,707 @@
+import { normalizeTextCaseAndWhitespace } from '@/utils';
+
 export type HardcodedLocation = {
-  city?: string | null;
-  state?: string | null;
-  country?: string | null;
-  // When true, downstream search should enforce exact city match if possible
-  forceExactCity?: boolean;
+	city?: string | null;
+	state?: string | null;
+	country?: string | null;
+	// When true, downstream search should enforce exact city match if possible
+	forceExactCity?: boolean;
 };
 
 export type LocationOverrideResult = {
-  overrides: { city: string | null; state: string | null; country: string | null; restOfQuery: string };
-  penaltyCities: string[];
-  forceCityExactCity?: string;
-  // When provided, downstream search should accept any of these state values as exact matches
-  forceStateAny?: string[];
-  // When provided, downstream search should accept any of these city values as exact matches
-  forceCityAny?: string[];
-  penaltyTerms: string[];
-  strictPenalty?: boolean;
+	overrides: {
+		city: string | null;
+		state: string | null;
+		country: string | null;
+		restOfQuery: string;
+	};
+	penaltyCities: string[];
+	forceCityExactCity?: string;
+	// When provided, downstream search should accept any of these state values as exact matches
+	forceStateAny?: string[];
+	// When provided, downstream search should accept any of these city values as exact matches
+	forceCityAny?: string[];
+	penaltyTerms: string[];
+	strictPenalty?: boolean;
 };
 
 // Minimal, deterministic aliases. Extend as needed.
 const LOCATION_ALIASES: Record<string, HardcodedLocation> = {
-  // User request: "manhattan" corresponds to New York, New York (strict city match)
-  manhattan: { city: 'New York', state: 'New York', country: 'United States of America', forceExactCity: true },
-  // NYC maps to multiple boroughs/cities; we enforce state strictly and allow multiple cities via forceCityAny
-  nyc: { city: null, state: 'New York', country: 'United States of America' },
-  // Explicit handling for "New York City"
-  'new york city': { city: null, state: 'New York', country: 'United States of America' },
-  'newyorkcity': { city: null, state: 'New York', country: 'United States of America' },
-  // Philadelphia strict handling (correct spelling, common nickname, and misspelling)
-  philadelphia: { city: 'Philadelphia', state: 'Pennsylvania', country: 'United States of America', forceExactCity: true },
-  philly: { city: 'Philadelphia', state: 'Pennsylvania', country: 'United States of America', forceExactCity: true },
-  phiadelphia: { city: 'Philadelphia', state: 'Pennsylvania', country: 'United States of America', forceExactCity: true },
-  brooklyn: { city: 'Brooklyn', state: 'New York', country: 'United States of America', forceExactCity: true },
-  boston: { city: 'Boston', state: 'Massachusetts', country: 'United States of America', forceExactCity: true },
-  baltimore: { city: 'Baltimore', state: 'Maryland', country: 'United States of America', forceExactCity: true },
-  chicago: { city: 'Chicago', state: 'Illinois', country: 'United States of America', forceExactCity: true },
-  nashville: { city: 'Nashville', state: 'Tennessee', country: 'United States of America', forceExactCity: true },
-  memphis: { city: 'Memphis', state: 'Tennessee', country: 'United States of America', forceExactCity: true },
-  'washington dc': { city: 'Washington', state: 'District of Columbia', country: 'United States of America', forceExactCity: true },
-  'washington, dc': { city: 'Washington', state: 'District of Columbia', country: 'United States of America', forceExactCity: true },
-  'washingtondc': { city: 'Washington', state: 'District of Columbia', country: 'United States of America', forceExactCity: true },
-  'district of columbia': { city: 'Washington', state: 'District of Columbia', country: 'United States of America', forceExactCity: true },
-  'los angeles': { city: 'Los Angeles', state: 'California', country: 'United States of America', forceExactCity: true },
-  'losangeles': { city: 'Los Angeles', state: 'California', country: 'United States of America', forceExactCity: true },
-  'las vegas': { city: 'Las Vegas', state: 'Nevada', country: 'United States of America', forceExactCity: true },
-  'new orleans': { city: 'New Orleans', state: 'Louisiana', country: 'United States of America', forceExactCity: true },
-  'neworleans': { city: 'New Orleans', state: 'Louisiana', country: 'United States of America', forceExactCity: true },
-  'san antonio': { city: 'San Antonio', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  'san diego': { city: 'San Diego', state: 'California', country: 'United States of America', forceExactCity: true },
-  'san jose': { city: 'San Jose', state: 'California', country: 'United States of America', forceExactCity: true },
-  'san francisco': { city: 'San Francisco', state: 'California', country: 'United States of America', forceExactCity: true },
-  'sanfrancisco': { city: 'San Francisco', state: 'California', country: 'United States of America', forceExactCity: true },
-  fresno: { city: 'Fresno', state: 'California', country: 'United States of America', forceExactCity: true },
-  sacramento: { city: 'Sacramento', state: 'California', country: 'United States of America', forceExactCity: true },
-  oakland: { city: 'Oakland', state: 'California', country: 'United States of America', forceExactCity: true },
-  'long beach': { city: 'Long Beach', state: 'California', country: 'United States of America', forceExactCity: true },
-  'longbeach': { city: 'Long Beach', state: 'California', country: 'United States of America', forceExactCity: true },
-  buffallo: { city: 'Buffalo', state: 'New York', country: 'United States of America', forceExactCity: true },
-  rochester: { city: 'Rochester', state: 'New York', country: 'United States of America', forceExactCity: true },
-  indianapolis: { city: 'Indianapolis', state: 'Indiana', country: 'United States of America', forceExactCity: true },
-  jacksonville: { city: 'Jacksonville', state: 'Florida', country: 'United States of America', forceExactCity: true },
-  miami: { city: 'Miami', state: 'Florida', country: 'United States of America', forceExactCity: true },
-  houston: { city: 'Houston', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  austin: { city: 'Austin', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  dallas: { city: 'Dallas', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  'fort worth': { city: 'Fort Worth', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  'fortworth': { city: 'Fort Worth', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  'el paso': { city: 'El Paso', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  'elpaso': { city: 'El Paso', state: 'Texas', country: 'United States of America', forceExactCity: true },
-  atlanta: { city: 'Atlanta', state: 'Georgia', country: 'United States of America', forceExactCity: true },
-  louisville: { city: 'Louisville', state: 'Kentucky', country: 'United States of America', forceExactCity: true },
-  charlotte: { city: 'Charlotte', state: 'North Carolina', country: 'United States of America', forceExactCity: true },
-  raleigh: { city: 'Raleigh', state: 'North Carolina', country: 'United States of America', forceExactCity: true },
-  'virginia beach': { city: 'Virginia Beach', state: 'Virginia', country: 'United States of America', forceExactCity: true },
-  'virginiabeach': { city: 'Virginia Beach', state: 'Virginia', country: 'United States of America', forceExactCity: true },
-  'virginia beah': { city: 'Virginia Beach', state: 'Virginia', country: 'United States of America', forceExactCity: true },
-  minneapolis: { city: 'Minneapolis', state: 'Minnesota', country: 'United States of America', forceExactCity: true },
-  seattle: { city: 'Seattle', state: 'Washington', country: 'United States of America', forceExactCity: true },
-  denver: { city: 'Denver', state: 'Colorado', country: 'United States of America', forceExactCity: true },
-  'colorado springs': { city: 'Colorado Springs', state: 'Colorado', country: 'United States of America', forceExactCity: true },
-  'coloradosprings': { city: 'Colorado Springs', state: 'Colorado', country: 'United States of America', forceExactCity: true },
-  hartford: { city: 'Hartford', state: 'Connecticut', country: 'United States of America', forceExactCity: true },
-  'kansas city': { city: 'Kansas City', state: 'Missouri', country: 'United States of America', forceExactCity: true },
-  'kansascity': { city: 'Kansas City', state: 'Missouri', country: 'United States of America', forceExactCity: true },
-  'oklahoma city': { city: 'Oklahoma City', state: 'Oklahoma', country: 'United States of America', forceExactCity: true },
-  'oklahomacity': { city: 'Oklahoma City', state: 'Oklahoma', country: 'United States of America', forceExactCity: true },
-  tulsa: { city: 'Tulsa', state: 'Oklahoma', country: 'United States of America', forceExactCity: true },
-  detroit: { city: 'Detroit', state: 'Michigan', country: 'United States of America', forceExactCity: true },
-  albuquerque: { city: 'Albuquerque', state: 'New Mexico', country: 'United States of America', forceExactCity: true },
-  albequerque: { city: 'Albuquerque', state: 'New Mexico', country: 'United States of America', forceExactCity: true },
-  milwaukee: { city: 'Milwaukee', state: 'Wisconsin', country: 'United States of America', forceExactCity: true },
-  wilmington: { city: 'Wilmington', state: 'Delaware', country: 'United States of America', forceExactCity: true },
-  harrisburg: { city: 'Harrisburg', state: 'Pennsylvania', country: 'United States of America', forceExactCity: true },
-  omaha: { city: 'Omaha', state: 'Nebraska', country: 'United States of America', forceExactCity: true },
-  cleveland: { city: 'Cleveland', state: 'Ohio', country: 'United States of America', forceExactCity: true },
-  columbus: { city: 'Columbus', state: 'Ohio', country: 'United States of America', forceExactCity: true },
-  wichita: { city: 'Wichita', state: 'Kansas', country: 'United States of America', forceExactCity: true },
-  pheonix: { city: 'Pheonix', state: 'Arizona', country: 'United States of America', forceExactCity: true },
-  phoenix: { city: 'Phoenix', state: 'Arizona', country: 'United States of America', forceExactCity: true },
-  tucson: { city: 'Tucson', state: 'Arizona', country: 'United States of America', forceExactCity: true },
-  mesa: { city: 'Mesa', state: 'Arizona', country: 'United States of America', forceExactCity: true },
+	// User request: "manhattan" corresponds to New York, New York (strict city match)
+	manhattan: {
+		city: 'New York',
+		state: 'New York',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	// NYC maps to multiple boroughs/cities; we enforce state strictly and allow multiple cities via forceCityAny
+	nyc: { city: null, state: 'New York', country: 'United States of America' },
+	// Explicit handling for "New York City"
+	'new york city': { city: null, state: 'New York', country: 'United States of America' },
+	newyorkcity: { city: null, state: 'New York', country: 'United States of America' },
+	// Philadelphia strict handling (correct spelling, common nickname, and misspelling)
+	philadelphia: {
+		city: 'Philadelphia',
+		state: 'Pennsylvania',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	philly: {
+		city: 'Philadelphia',
+		state: 'Pennsylvania',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	phiadelphia: {
+		city: 'Philadelphia',
+		state: 'Pennsylvania',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	brooklyn: {
+		city: 'Brooklyn',
+		state: 'New York',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	boston: {
+		city: 'Boston',
+		state: 'Massachusetts',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	baltimore: {
+		city: 'Baltimore',
+		state: 'Maryland',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	chicago: {
+		city: 'Chicago',
+		state: 'Illinois',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	nashville: {
+		city: 'Nashville',
+		state: 'Tennessee',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	memphis: {
+		city: 'Memphis',
+		state: 'Tennessee',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'washington dc': {
+		city: 'Washington',
+		state: 'District of Columbia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'washington, dc': {
+		city: 'Washington',
+		state: 'District of Columbia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	washingtondc: {
+		city: 'Washington',
+		state: 'District of Columbia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'district of columbia': {
+		city: 'Washington',
+		state: 'District of Columbia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'los angeles': {
+		city: 'Los Angeles',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	losangeles: {
+		city: 'Los Angeles',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'las vegas': {
+		city: 'Las Vegas',
+		state: 'Nevada',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'new orleans': {
+		city: 'New Orleans',
+		state: 'Louisiana',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	neworleans: {
+		city: 'New Orleans',
+		state: 'Louisiana',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'san antonio': {
+		city: 'San Antonio',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'san diego': {
+		city: 'San Diego',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'san jose': {
+		city: 'San Jose',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'san francisco': {
+		city: 'San Francisco',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	sanfrancisco: {
+		city: 'San Francisco',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	fresno: {
+		city: 'Fresno',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	sacramento: {
+		city: 'Sacramento',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	oakland: {
+		city: 'Oakland',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'long beach': {
+		city: 'Long Beach',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	longbeach: {
+		city: 'Long Beach',
+		state: 'California',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	buffallo: {
+		city: 'Buffalo',
+		state: 'New York',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	rochester: {
+		city: 'Rochester',
+		state: 'New York',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	indianapolis: {
+		city: 'Indianapolis',
+		state: 'Indiana',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	jacksonville: {
+		city: 'Jacksonville',
+		state: 'Florida',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	miami: {
+		city: 'Miami',
+		state: 'Florida',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	houston: {
+		city: 'Houston',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	austin: {
+		city: 'Austin',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	dallas: {
+		city: 'Dallas',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'fort worth': {
+		city: 'Fort Worth',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	fortworth: {
+		city: 'Fort Worth',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'el paso': {
+		city: 'El Paso',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	elpaso: {
+		city: 'El Paso',
+		state: 'Texas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	atlanta: {
+		city: 'Atlanta',
+		state: 'Georgia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	louisville: {
+		city: 'Louisville',
+		state: 'Kentucky',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	charlotte: {
+		city: 'Charlotte',
+		state: 'North Carolina',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	raleigh: {
+		city: 'Raleigh',
+		state: 'North Carolina',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'virginia beach': {
+		city: 'Virginia Beach',
+		state: 'Virginia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	virginiabeach: {
+		city: 'Virginia Beach',
+		state: 'Virginia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'virginia beah': {
+		city: 'Virginia Beach',
+		state: 'Virginia',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	minneapolis: {
+		city: 'Minneapolis',
+		state: 'Minnesota',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	seattle: {
+		city: 'Seattle',
+		state: 'Washington',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	denver: {
+		city: 'Denver',
+		state: 'Colorado',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'colorado springs': {
+		city: 'Colorado Springs',
+		state: 'Colorado',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	coloradosprings: {
+		city: 'Colorado Springs',
+		state: 'Colorado',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	hartford: {
+		city: 'Hartford',
+		state: 'Connecticut',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'kansas city': {
+		city: 'Kansas City',
+		state: 'Missouri',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	kansascity: {
+		city: 'Kansas City',
+		state: 'Missouri',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	'oklahoma city': {
+		city: 'Oklahoma City',
+		state: 'Oklahoma',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	oklahomacity: {
+		city: 'Oklahoma City',
+		state: 'Oklahoma',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	tulsa: {
+		city: 'Tulsa',
+		state: 'Oklahoma',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	detroit: {
+		city: 'Detroit',
+		state: 'Michigan',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	albuquerque: {
+		city: 'Albuquerque',
+		state: 'New Mexico',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	albequerque: {
+		city: 'Albuquerque',
+		state: 'New Mexico',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	milwaukee: {
+		city: 'Milwaukee',
+		state: 'Wisconsin',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	wilmington: {
+		city: 'Wilmington',
+		state: 'Delaware',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	harrisburg: {
+		city: 'Harrisburg',
+		state: 'Pennsylvania',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	omaha: {
+		city: 'Omaha',
+		state: 'Nebraska',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	cleveland: {
+		city: 'Cleveland',
+		state: 'Ohio',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	columbus: {
+		city: 'Columbus',
+		state: 'Ohio',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	wichita: {
+		city: 'Wichita',
+		state: 'Kansas',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	pheonix: {
+		city: 'Pheonix',
+		state: 'Arizona',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	phoenix: {
+		city: 'Phoenix',
+		state: 'Arizona',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	tucson: {
+		city: 'Tucson',
+		state: 'Arizona',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
+	mesa: {
+		city: 'Mesa',
+		state: 'Arizona',
+		country: 'United States of America',
+		forceExactCity: true,
+	},
 };
-
-function normalize(text: string): string {
-  return text.toLowerCase();
-}
 
 // Synonyms for state values to ensure strict matching allows common abbreviations
 const STATE_SYNONYMS: Record<string, string[]> = {
-  'district of columbia': ['District of Columbia', 'DC'],
-  'dc': ['District of Columbia', 'DC'],
-  'new york': ['New York', 'NY'],
-  'pennsylvania': ['Pennsylvania', 'PA'],
-  'massachusetts': ['Massachusetts', 'MA'],
-  'maryland': ['Maryland', 'MD'],
-  'illinois': ['Illinois', 'IL'],
-  'alabama': ['Alabama', 'AL'],
-  'al': ['Alabama', 'AL'],
-  'alaska': ['Alaska', 'AK'],
-  'ak': ['Alaska', 'AK'],
-  'arizona': ['Arizona', 'AZ'],
-  'az': ['Arizona', 'AZ'],
-  'arkansas': ['Arkansas', 'AR'],
-  'ar': ['Arkansas', 'AR'],
-  'california': ['California', 'CA'],
-  'ca': ['California', 'CA'],
-  'colorado': ['Colorado', 'CO'],
-  'co': ['Colorado', 'CO'],
-  'connecticut': ['Connecticut', 'CT'],
-  'ct': ['Connecticut', 'CT'],
-  'delaware': ['Delaware', 'DE'],
-  'de': ['Delaware', 'DE'],
-  'florida': ['Florida', 'FL'],
-  'fl': ['Florida', 'FL'],
-  'georgia': ['Georgia', 'GA'],
-  'ga': ['Georgia', 'GA'],
-  'hawaii': ['Hawaii', 'HI'],
-  'hi': ['Hawaii', 'HI'],
-  'idaho': ['Idaho', 'ID'],
-  'id': ['Idaho', 'ID'],
-  'il': ['Illinois', 'IL'],
-  'indiana': ['Indiana', 'IN'],
-  'in': ['Indiana', 'IN'],
-  'iowa': ['Iowa', 'IA'],
-  'ia': ['Iowa', 'IA'],
-  'kansas': ['Kansas', 'KS'],
-  'ks': ['Kansas', 'KS'],
-  'kentucky': ['Kentucky', 'KY'],
-  'ky': ['Kentucky', 'KY'],
-  'louisiana': ['Louisiana', 'LA'],
-  'la': ['Louisiana', 'LA'],
-  'maine': ['Maine', 'ME'],
-  'me': ['Maine', 'ME'],
-  'md': ['Maryland', 'MD'],
-  'ma': ['Massachusetts', 'MA'],
-  'michigan': ['Michigan', 'MI'],
-  'mi': ['Michigan', 'MI'],
-  'minnesota': ['Minnesota', 'MN'],
-  'mn': ['Minnesota', 'MN'],
-  'mississippi': ['Mississippi', 'MS'],
-  'ms': ['Mississippi', 'MS'],
-  'missouri': ['Missouri', 'MO'],
-  'mo': ['Missouri', 'MO'],
-  'montana': ['Montana', 'MT'],
-  'mt': ['Montana', 'MT'],
-  'nebraska': ['Nebraska', 'NE'],
-  'ne': ['Nebraska', 'NE'],
-  'nevada': ['Nevada', 'NV'],
-  'nv': ['Nevada', 'NV'],
-  'new hampshire': ['New Hampshire', 'NH'],
-  'nh': ['New Hampshire', 'NH'],
-  'new jersey': ['New Jersey', 'NJ'],
-  'nj': ['New Jersey', 'NJ'],
-  'new mexico': ['New Mexico', 'NM'],
-  'nm': ['New Mexico', 'NM'],
-  'ny': ['New York', 'NY'],
-  'north carolina': ['North Carolina', 'NC'],
-  'nc': ['North Carolina', 'NC'],
-  'north dakota': ['North Dakota', 'ND'],
-  'nd': ['North Dakota', 'ND'],
-  'ohio': ['Ohio', 'OH'],
-  'oh': ['Ohio', 'OH'],
-  'oklahoma': ['Oklahoma', 'OK'],
-  'ok': ['Oklahoma', 'OK'],
-  'oregon': ['Oregon', 'OR'],
-  'or': ['Oregon', 'OR'],
-  'pa': ['Pennsylvania', 'PA'],
-  'rhode island': ['Rhode Island', 'RI'],
-  'ri': ['Rhode Island', 'RI'],
-  'south carolina': ['South Carolina', 'SC'],
-  'sc': ['South Carolina', 'SC'],
-  'south dakota': ['South Dakota', 'SD'],
-  'sd': ['South Dakota', 'SD'],
-  'tennessee': ['Tennessee', 'TN'],
-  'tn': ['Tennessee', 'TN'],
-  'texas': ['Texas', 'TX'],
-  'tx': ['Texas', 'TX'],
-  'utah': ['Utah', 'UT'],
-  'ut': ['Utah', 'UT'],
-  'vermont': ['Vermont', 'VT'],
-  'vt': ['Vermont', 'VT'],
-  'virginia': ['Virginia', 'VA'],
-  'va': ['Virginia', 'VA'],
-  'washington': ['Washington', 'WA'],
-  'wa': ['Washington', 'WA'],
-  'west virginia': ['West Virginia', 'WV'],
-  'wv': ['West Virginia', 'WV'],
-  'wisconsin': ['Wisconsin', 'WI'],
-  'wi': ['Wisconsin', 'WI'],
-  'wyoming': ['Wyoming', 'WY'],
-  'wy': ['Wyoming', 'WY'],
+	'district of columbia': ['District of Columbia', 'DC'],
+	dc: ['District of Columbia', 'DC'],
+	'new york': ['New York', 'NY'],
+	pennsylvania: ['Pennsylvania', 'PA'],
+	massachusetts: ['Massachusetts', 'MA'],
+	maryland: ['Maryland', 'MD'],
+	illinois: ['Illinois', 'IL'],
+	alabama: ['Alabama', 'AL'],
+	al: ['Alabama', 'AL'],
+	alaska: ['Alaska', 'AK'],
+	ak: ['Alaska', 'AK'],
+	arizona: ['Arizona', 'AZ'],
+	az: ['Arizona', 'AZ'],
+	arkansas: ['Arkansas', 'AR'],
+	ar: ['Arkansas', 'AR'],
+	california: ['California', 'CA'],
+	ca: ['California', 'CA'],
+	colorado: ['Colorado', 'CO'],
+	co: ['Colorado', 'CO'],
+	connecticut: ['Connecticut', 'CT'],
+	ct: ['Connecticut', 'CT'],
+	delaware: ['Delaware', 'DE'],
+	de: ['Delaware', 'DE'],
+	florida: ['Florida', 'FL'],
+	fl: ['Florida', 'FL'],
+	georgia: ['Georgia', 'GA'],
+	ga: ['Georgia', 'GA'],
+	hawaii: ['Hawaii', 'HI'],
+	hi: ['Hawaii', 'HI'],
+	idaho: ['Idaho', 'ID'],
+	id: ['Idaho', 'ID'],
+	il: ['Illinois', 'IL'],
+	indiana: ['Indiana', 'IN'],
+	in: ['Indiana', 'IN'],
+	iowa: ['Iowa', 'IA'],
+	ia: ['Iowa', 'IA'],
+	kansas: ['Kansas', 'KS'],
+	ks: ['Kansas', 'KS'],
+	kentucky: ['Kentucky', 'KY'],
+	ky: ['Kentucky', 'KY'],
+	louisiana: ['Louisiana', 'LA'],
+	la: ['Louisiana', 'LA'],
+	maine: ['Maine', 'ME'],
+	me: ['Maine', 'ME'],
+	md: ['Maryland', 'MD'],
+	ma: ['Massachusetts', 'MA'],
+	michigan: ['Michigan', 'MI'],
+	mi: ['Michigan', 'MI'],
+	minnesota: ['Minnesota', 'MN'],
+	mn: ['Minnesota', 'MN'],
+	mississippi: ['Mississippi', 'MS'],
+	ms: ['Mississippi', 'MS'],
+	missouri: ['Missouri', 'MO'],
+	mo: ['Missouri', 'MO'],
+	montana: ['Montana', 'MT'],
+	mt: ['Montana', 'MT'],
+	nebraska: ['Nebraska', 'NE'],
+	ne: ['Nebraska', 'NE'],
+	nevada: ['Nevada', 'NV'],
+	nv: ['Nevada', 'NV'],
+	'new hampshire': ['New Hampshire', 'NH'],
+	nh: ['New Hampshire', 'NH'],
+	'new jersey': ['New Jersey', 'NJ'],
+	nj: ['New Jersey', 'NJ'],
+	'new mexico': ['New Mexico', 'NM'],
+	nm: ['New Mexico', 'NM'],
+	ny: ['New York', 'NY'],
+	'north carolina': ['North Carolina', 'NC'],
+	nc: ['North Carolina', 'NC'],
+	'north dakota': ['North Dakota', 'ND'],
+	nd: ['North Dakota', 'ND'],
+	ohio: ['Ohio', 'OH'],
+	oh: ['Ohio', 'OH'],
+	oklahoma: ['Oklahoma', 'OK'],
+	ok: ['Oklahoma', 'OK'],
+	oregon: ['Oregon', 'OR'],
+	or: ['Oregon', 'OR'],
+	pa: ['Pennsylvania', 'PA'],
+	'rhode island': ['Rhode Island', 'RI'],
+	ri: ['Rhode Island', 'RI'],
+	'south carolina': ['South Carolina', 'SC'],
+	sc: ['South Carolina', 'SC'],
+	'south dakota': ['South Dakota', 'SD'],
+	sd: ['South Dakota', 'SD'],
+	tennessee: ['Tennessee', 'TN'],
+	tn: ['Tennessee', 'TN'],
+	texas: ['Texas', 'TX'],
+	tx: ['Texas', 'TX'],
+	utah: ['Utah', 'UT'],
+	ut: ['Utah', 'UT'],
+	vermont: ['Vermont', 'VT'],
+	vt: ['Vermont', 'VT'],
+	virginia: ['Virginia', 'VA'],
+	va: ['Virginia', 'VA'],
+	washington: ['Washington', 'WA'],
+	wa: ['Washington', 'WA'],
+	'west virginia': ['West Virginia', 'WV'],
+	wv: ['West Virginia', 'WV'],
+	wisconsin: ['Wisconsin', 'WI'],
+	wi: ['Wisconsin', 'WI'],
+	wyoming: ['Wyoming', 'WY'],
+	wy: ['Wyoming', 'WY'],
 };
 
 export function applyHardcodedLocationOverrides(
-  rawQuery: string,
-  parsed: { city: string | null; state: string | null; country: string | null; restOfQuery: string }
+	rawQuery: string,
+	parsed: {
+		city: string | null;
+		state: string | null;
+		country: string | null;
+		restOfQuery: string;
+	}
 ): LocationOverrideResult {
-  const lowered = normalize(rawQuery);
+	const lowered = normalizeTextCaseAndWhitespace(rawQuery);
 
-  // Special-case: standalone "DC" tokens (e.g., "Music venues DC", "in D.C.") map to Washington, DC
-  // Accept variations like: DC, D.C, D.C., D C
-  const dcTokenRegex = /(^|[^a-z])d\.?\s*c\.?([^a-z]|$)/i;
-  if (dcTokenRegex.test(lowered)) {
-    const cleanedRest = parsed.restOfQuery
-      ? parsed.restOfQuery.replace(/\bD\.?\s*C\.?\b/gi, '').replace(/\s+/g, ' ').trim()
-      : parsed.restOfQuery;
+	// Special-case: standalone "DC" tokens (e.g., "Music venues DC", "in D.C.") map to Washington, DC
+	// Accept variations like: DC, D.C, D.C., D C
+	const dcTokenRegex = /(^|[^a-z])d\.?\s*c\.?([^a-z]|$)/i;
+	if (dcTokenRegex.test(lowered)) {
+		const cleanedRest = parsed.restOfQuery
+			? parsed.restOfQuery
+					.replace(/\bD\.?\s*C\.?\b/gi, '')
+					.replace(/\s+/g, ' ')
+					.trim()
+			: parsed.restOfQuery;
 
-    return {
-      overrides: {
-        city: 'Washington',
-        state: 'District of Columbia',
-        country: 'United States of America',
-        restOfQuery: cleanedRest,
-      },
-      penaltyCities: [],
-      forceCityExactCity: 'Washington',
-      forceStateAny: ['District of Columbia', 'DC'],
-      penaltyTerms: [],
-      strictPenalty: false,
-    };
-  }
+		return {
+			overrides: {
+				city: 'Washington',
+				state: 'District of Columbia',
+				country: 'United States of America',
+				restOfQuery: cleanedRest,
+			},
+			penaltyCities: [],
+			forceCityExactCity: 'Washington',
+			forceStateAny: ['District of Columbia', 'DC'],
+			penaltyTerms: [],
+			strictPenalty: false,
+		};
+	}
 
-  // Special-case: standalone "LA" tokens that likely mean Los Angeles.
-  // Prefer Los Angeles unless Louisiana is explicitly referenced.
-  const laTokenRegex = /(^|[^a-z])l\.?\s*a\.?([^a-z]|$)/i;
-  const explicitLouisiana = /\blouisiana\b/i.test(lowered) || /\bnew orleans\b|\bbaton rouge\b|\bshreveport\b/i.test(lowered);
-  if (laTokenRegex.test(lowered) && !explicitLouisiana) {
-    const cleanedRest = parsed.restOfQuery
-      ? parsed.restOfQuery.replace(/\bL\.?\s*A\.?\b/gi, '').replace(/\s+/g, ' ').trim()
-      : parsed.restOfQuery;
-    return {
-      overrides: {
-        city: 'Los Angeles',
-        state: 'California',
-        country: 'United States of America',
-        restOfQuery: cleanedRest,
-      },
-      penaltyCities: [],
-      forceCityExactCity: 'Los Angeles',
-      forceStateAny: ['California', 'CA'],
-      penaltyTerms: [],
-      strictPenalty: false,
-    };
-  }
+	// Special-case: standalone "LA" tokens that likely mean Los Angeles.
+	// Prefer Los Angeles unless Louisiana is explicitly referenced.
+	const laTokenRegex = /(^|[^a-z])l\.?\s*a\.?([^a-z]|$)/i;
+	const explicitLouisiana =
+		/\blouisiana\b/i.test(lowered) ||
+		/\bnew orleans\b|\bbaton rouge\b|\bshreveport\b/i.test(lowered);
+	if (laTokenRegex.test(lowered) && !explicitLouisiana) {
+		const cleanedRest = parsed.restOfQuery
+			? parsed.restOfQuery
+					.replace(/\bL\.?\s*A\.?\b/gi, '')
+					.replace(/\s+/g, ' ')
+					.trim()
+			: parsed.restOfQuery;
+		return {
+			overrides: {
+				city: 'Los Angeles',
+				state: 'California',
+				country: 'United States of America',
+				restOfQuery: cleanedRest,
+			},
+			penaltyCities: [],
+			forceCityExactCity: 'Los Angeles',
+			forceStateAny: ['California', 'CA'],
+			penaltyTerms: [],
+			strictPenalty: false,
+		};
+	}
 
-  // Find alias present in the query using strict, word-boundary-aware matching.
-  // Prefer the longest matching alias to avoid partial overshadowing (e.g., "washington dc" over "dc").
-  const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const aliasKeys = Object.keys(LOCATION_ALIASES);
-  const matchingAliases = aliasKeys.filter((key) => {
-    const pattern = new RegExp(`\\b${escapeRegex(key)}\\b`, 'i');
-    return pattern.test(lowered);
-  });
-  const hit = matchingAliases.sort((a, b) => b.length - a.length)[0];
-  if (!hit) {
-    return {
-      overrides: parsed,
-      penaltyCities: [],
-      penaltyTerms: [],
-    };
-  }
+	// Find alias present in the query using strict, word-boundary-aware matching.
+	// Prefer the longest matching alias to avoid partial overshadowing (e.g., "washington dc" over "dc").
+	const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const aliasKeys = Object.keys(LOCATION_ALIASES);
+	const matchingAliases = aliasKeys.filter((key) => {
+		const pattern = new RegExp(`\\b${escapeRegex(key)}\\b`, 'i');
+		return pattern.test(lowered);
+	});
+	const hit = matchingAliases.sort((a, b) => b.length - a.length)[0];
+	if (!hit) {
+		return {
+			overrides: parsed,
+			penaltyCities: [],
+			penaltyTerms: [],
+		};
+	}
 
-  const alias = LOCATION_ALIASES[hit];
+	const alias = LOCATION_ALIASES[hit];
 
-  // Override parsed values
-  const city = alias.city ?? parsed.city;
-  const state = alias.state ?? parsed.state;
-  const country = alias.country ?? parsed.country;
+	// Override parsed values
+	const city = alias.city ?? parsed.city;
+	const state = alias.state ?? parsed.state;
+	const country = alias.country ?? parsed.country;
 
-  // Remove the alias token from the restOfQuery using boundary-aware replacement
-  const cleanedRest = parsed.restOfQuery
-    ? parsed.restOfQuery
-        .replace(new RegExp(`\\b${escapeRegex(hit)}\\b`, 'ig'), '')
-        .replace(/\s+/g, ' ')
-        .trim()
-    : parsed.restOfQuery;
+	// Remove the alias token from the restOfQuery using boundary-aware replacement
+	const cleanedRest = parsed.restOfQuery
+		? parsed.restOfQuery
+				.replace(new RegExp(`\\b${escapeRegex(hit)}\\b`, 'ig'), '')
+				.replace(/\s+/g, ' ')
+				.trim()
+		: parsed.restOfQuery;
 
-  const forceCityExact = alias.forceExactCity && city ? city : undefined;
-  // If we have a known state, allow strict matching against any of its common synonyms/abbreviations
-  const stateKey = (state || '').toLowerCase();
-  const forceStateAny = stateKey && STATE_SYNONYMS[stateKey] ? STATE_SYNONYMS[stateKey] : undefined;
-  // NYC: allow both New York and Brooklyn as exact city matches
-  // NYC and "New York City": allow both New York and Brooklyn as exact city matches
-  const forceCityAny = (hit === 'nyc' || hit === 'new york city' || hit === 'newyorkcity')
-    ? ['New York', 'Brooklyn']
-    : undefined;
+	const forceCityExact = alias.forceExactCity && city ? city : undefined;
+	// If we have a known state, allow strict matching against any of its common synonyms/abbreviations
+	const stateKey = (state || '').toLowerCase();
+	const forceStateAny =
+		stateKey && STATE_SYNONYMS[stateKey] ? STATE_SYNONYMS[stateKey] : undefined;
+	// NYC: allow both New York and Brooklyn as exact city matches
+	// NYC and "New York City": allow both New York and Brooklyn as exact city matches
+	const forceCityAny =
+		hit === 'nyc' || hit === 'new york city' || hit === 'newyorkcity'
+			? ['New York', 'Brooklyn']
+			: undefined;
 
-  return {
-    overrides: {
-      city,
-      state,
-      country,
-      restOfQuery: cleanedRest,
-    },
-    penaltyCities: [],
-    // Hint the downstream search to require an exact city match when appropriate
-    forceCityExactCity: forceCityExact,
-    forceStateAny,
-    forceCityAny,
-    penaltyTerms: [],
-    strictPenalty: false,
-  };
+	return {
+		overrides: {
+			city,
+			state,
+			country,
+			restOfQuery: cleanedRest,
+		},
+		penaltyCities: [],
+		// Hint the downstream search to require an exact city match when appropriate
+		forceCityExactCity: forceCityExact,
+		forceStateAny,
+		forceCityAny,
+		penaltyTerms: [],
+		strictPenalty: false,
+	};
 }
-
-

--- a/src/app/api/_utils/vectorDb.ts
+++ b/src/app/api/_utils/vectorDb.ts
@@ -430,8 +430,9 @@ export const searchSimilarContacts = async (
 	});
 
 	// Post-process results with optional location boosts and institutional penalties
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const processResultsWithLocationBoost = (hits: any[]): any[] => {
+	const processResultsWithLocationBoost = (
+		hits: estypes.SearchHit[]
+	): estypes.SearchHit[] => {
 		const skipBoosts = locationStrategy === 'strict' || boosts.exact === 0;
 
 		const penalties = new Set((options?.penaltyCities || []).map((c) => c.toLowerCase()));

--- a/src/app/api/_utils/vectorDb.ts
+++ b/src/app/api/_utils/vectorDb.ts
@@ -9,8 +9,8 @@ const VECTOR_DIMENSION = 1536;
 const INDEX_NAME = 'contacts';
 
 const openai = new OpenAI({
-    apiKey: process.env.OPEN_AI_API_KEY!,
-    timeout: 15000, // 15s client timeout so embedding calls fail fast
+	apiKey: process.env.OPEN_AI_API_KEY!,
+	timeout: 15000, // 15s client timeout so embedding calls fail fast
 });
 
 const elasticsearch = new Client({
@@ -323,20 +323,17 @@ export type QueryJson = {
 	restOfQuery: string;
 };
 export const searchSimilarContacts = async (
-    queryJson: QueryJson,
-    limit: number = 10,
-    // minScore reserved for future use
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    minScore: number = 0.3,
-    locationStrategy: 'strict' | 'flexible' | 'broad' = 'flexible',
-    options?: {
-        penaltyCities?: string[];
-        forceCityExactCity?: string;
-        forceStateAny?: string[];
-        forceCityAny?: string[];
-        penaltyTerms?: string[];
-        strictPenalty?: boolean;
-    }
+	queryJson: QueryJson,
+	limit: number = 10,
+	locationStrategy: 'strict' | 'flexible' | 'broad' = 'flexible',
+	options?: {
+		penaltyCities?: string[];
+		forceCityExactCity?: string;
+		forceStateAny?: string[];
+		forceCityAny?: string[];
+		penaltyTerms?: string[];
+		strictPenalty?: boolean;
+	}
 ) => {
 	const response = await openai.embeddings.create({
 		input: queryJson.restOfQuery,
@@ -348,57 +345,66 @@ export const searchSimilarContacts = async (
 	const locationBoosts = {
 		strict: { exact: 0.0, fuzzy: 0.0 }, // No post-processing boost for strict (uses filters)
 		flexible: { exact: 0.2, fuzzy: 0.1 }, // Moderate location preference
-		broad: { exact: 0.1, fuzzy: 0.05 }   // Light location preference
+		broad: { exact: 0.1, fuzzy: 0.05 }, // Light location preference
 	};
 	const boosts = locationBoosts[locationStrategy];
 
-    // Build strict state/city filter for kNN (enforce exact state and exact city or any-of cities)
-    const buildStrictStateFilter = () => {
-        if (locationStrategy !== 'strict') return undefined;
-        const must: Record<string, unknown>[] = [];
-        if (options?.forceStateAny && options.forceStateAny.length > 0) {
-            must.push({
-                bool: {
-                    should: options.forceStateAny.map((s) => ({ term: { 'state.keyword': s.toLowerCase() } })),
-                    minimum_should_match: 1,
-                },
-            });
-        } else if (queryJson.state) {
-            must.push({ term: { 'state.keyword': queryJson.state.toLowerCase() } });
-        }
-        if (options?.forceCityExactCity) {
-            must.push({ term: { 'city.keyword': options.forceCityExactCity.toLowerCase() } });
-        }
-        if (options?.forceCityAny && options.forceCityAny.length > 0) {
-            must.push({
-                bool: {
-                    should: options.forceCityAny.map((c) => ({ term: { 'city.keyword': c.toLowerCase() } })),
-                    minimum_should_match: 1,
-                },
-            });
-        }
-        if (must.length === 0) return undefined;
-        return { bool: { filter: must } } as const;
-    };
+	// Build strict state/city filter for kNN (enforce exact state and exact city or any-of cities)
+	const buildStrictStateFilter = () => {
+		if (locationStrategy !== 'strict') return undefined;
+		const must: Record<string, unknown>[] = [];
+		if (options?.forceStateAny && options.forceStateAny.length > 0) {
+			must.push({
+				bool: {
+					should: options.forceStateAny.map((s) => ({
+						term: { 'state.keyword': s.toLowerCase() },
+					})),
+					minimum_should_match: 1,
+				},
+			});
+		} else if (queryJson.state) {
+			must.push({ term: { 'state.keyword': queryJson.state.toLowerCase() } });
+		}
+		if (options?.forceCityExactCity) {
+			must.push({ term: { 'city.keyword': options.forceCityExactCity.toLowerCase() } });
+		}
+		if (options?.forceCityAny && options.forceCityAny.length > 0) {
+			must.push({
+				bool: {
+					should: options.forceCityAny.map((c) => ({
+						term: { 'city.keyword': c.toLowerCase() },
+					})),
+					minimum_should_match: 1,
+				},
+			});
+		}
+		if (must.length === 0) return undefined;
+		return { bool: { filter: must } } as const;
+	};
 
-    const strictStateFilter = buildStrictStateFilter();
+	const strictStateFilter = buildStrictStateFilter();
 
 	// Pure kNN search - let vector embeddings handle semantic matching
-    const kValue = options?.penaltyTerms && options.penaltyTerms.length > 0
-        ? (locationStrategy === 'strict' ? Math.min(limit * 2, 200) : Math.min(limit * 6, 200))
-        : (locationStrategy === 'strict' ? limit : Math.min(limit * 3, 50));
+	const kValue =
+		options?.penaltyTerms && options.penaltyTerms.length > 0
+			? locationStrategy === 'strict'
+				? Math.min(limit * 2, 200)
+				: Math.min(limit * 6, 200)
+			: locationStrategy === 'strict'
+			? limit
+			: Math.min(limit * 3, 50);
 
-    const results = await elasticsearch.search<ContactDocument>({
+	const results = await elasticsearch.search<ContactDocument>({
 		index: INDEX_NAME,
-        knn: {
+		knn: {
 			field: 'vector_field',
 			query_vector: queryEmbedding,
-            k: kValue, // Get more candidates for filtering when we plan to demote results
-            // Keep candidate space bounded; large values can stall ES locally
-            num_candidates: Math.min(1000, Math.max(kValue * 5, 50)),
-            filter: strictStateFilter,
+			k: kValue, // Get more candidates for filtering when we plan to demote results
+			// Keep candidate space bounded; large values can stall ES locally
+			num_candidates: Math.min(1000, Math.max(kValue * 5, 50)),
+			filter: strictStateFilter,
 		},
-        size: Math.min(limit, 500),
+		size: Math.min(limit, 500),
 		fields: [
 			'contactId',
 			'email',
@@ -423,67 +429,85 @@ export const searchSimilarContacts = async (
 		_source: false,
 	});
 
-    // Post-process results with optional location boosts and institutional penalties
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const processResultsWithLocationBoost = (hits: any[]): any[] => {
+	// Post-process results with optional location boosts and institutional penalties
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const processResultsWithLocationBoost = (hits: any[]): any[] => {
 		const skipBoosts = locationStrategy === 'strict' || boosts.exact === 0;
 
-        const penalties = new Set((options?.penaltyCities || []).map((c) => c.toLowerCase()));
-        const penaltyTerms = new Set((options?.penaltyTerms || []).map((t) => t.toLowerCase()));
+		const penalties = new Set((options?.penaltyCities || []).map((c) => c.toLowerCase()));
+		const penaltyTerms = new Set(
+			(options?.penaltyTerms || []).map((t) => t.toLowerCase())
+		);
 
-        return hits.map(hit => {
-            let locationBoost = 0;
-			if (!skipBoosts) {
-				// Check for exact location matches
-                if (queryJson.state && hit.fields?.state?.[0]?.toLowerCase() === queryJson.state.toLowerCase()) {
-                    locationBoost += boosts.exact;
-                }
-                if (queryJson.city && hit.fields?.city?.[0]?.toLowerCase() === queryJson.city.toLowerCase()) {
-                    locationBoost += boosts.exact;
-                }
-                if (queryJson.country && hit.fields?.country?.[0]?.toLowerCase() === queryJson.country.toLowerCase()) {
-                    locationBoost += boosts.exact;
-                }
-				// Check for fuzzy location matches
-                if (queryJson.state && hit.fields?.state?.[0]) {
-                    const hitState = hit.fields.state[0].toLowerCase();
-                    const queryState = queryJson.state.toLowerCase();
-                    if (hitState.includes(queryState.substring(0, 2)) || queryState.includes(hitState.substring(0, 2))) {
-                        locationBoost += boosts.fuzzy;
-                    }
-                }
-            }
-			
-            // Soft penalties for specific cities (e.g., when query contains "manhattan")
-            const hitCity = String(hit.fields?.city?.[0] || '').toLowerCase();
-            let penalty = penalties.has(hitCity) ? 0.2 : 0; // small deduction for cities
+		return hits
+			.map((hit) => {
+				let locationBoost = 0;
+				if (!skipBoosts) {
+					// Check for exact location matches
+					if (
+						queryJson.state &&
+						hit.fields?.state?.[0]?.toLowerCase() === queryJson.state.toLowerCase()
+					) {
+						locationBoost += boosts.exact;
+					}
+					if (
+						queryJson.city &&
+						hit.fields?.city?.[0]?.toLowerCase() === queryJson.city.toLowerCase()
+					) {
+						locationBoost += boosts.exact;
+					}
+					if (
+						queryJson.country &&
+						hit.fields?.country?.[0]?.toLowerCase() === queryJson.country.toLowerCase()
+					) {
+						locationBoost += boosts.exact;
+					}
+					// Check for fuzzy location matches
+					if (queryJson.state && hit.fields?.state?.[0]) {
+						const hitState = hit.fields.state[0].toLowerCase();
+						const queryState = queryJson.state.toLowerCase();
+						if (
+							hitState.includes(queryState.substring(0, 2)) ||
+							queryState.includes(hitState.substring(0, 2))
+						) {
+							locationBoost += boosts.fuzzy;
+						}
+					}
+				}
 
-            // Soft penalty for university/college when query starts with "music venue(s)"
-            const headline = String(hit.fields?.headline?.[0] || '').toLowerCase();
-            const title = String(hit.fields?.title?.[0] || '').toLowerCase();
-            const company = String(hit.fields?.company?.[0] || '').toLowerCase();
-            const textBlob = `${headline} ${title} ${company}`;
-            for (const term of penaltyTerms) {
-                if (!term) continue;
-                const exact = new RegExp(`(^|\b)${term.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}(\b|$)`, 'i');
-                if (exact.test(textBlob)) {
-                    penalty += options?.strictPenalty ? 0.6 : 0.35; // much stronger in strictPenalty mode
-                } else if (textBlob.includes(term)) {
-                    penalty += options?.strictPenalty ? 0.35 : 0.2; // stronger partial penalty in strictPenalty mode
-                }
-            }
+				// Soft penalties for specific cities (e.g., when query contains "manhattan")
+				const hitCity = String(hit.fields?.city?.[0] || '').toLowerCase();
+				let penalty = penalties.has(hitCity) ? 0.2 : 0; // small deduction for cities
 
-            // Apply location boost and penalty to score
-            const originalScore = hit._score || 0;
-            const boostedScore = originalScore + locationBoost - penalty;
-			
-            return {
-                ...hit,
-                _score: boostedScore
-            };
-		})
-		.sort((a, b) => (b._score || 0) - (a._score || 0)) // Re-sort by boosted score
-		.slice(0, limit); // Apply final limit
+				// Soft penalty for university/college when query starts with "music venue(s)"
+				const headline = String(hit.fields?.headline?.[0] || '').toLowerCase();
+				const title = String(hit.fields?.title?.[0] || '').toLowerCase();
+				const company = String(hit.fields?.company?.[0] || '').toLowerCase();
+				const textBlob = `${headline} ${title} ${company}`;
+				for (const term of penaltyTerms) {
+					if (!term) continue;
+					const exact = new RegExp(
+						`(^|\b)${term.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}(\b|$)`,
+						'i'
+					);
+					if (exact.test(textBlob)) {
+						penalty += options?.strictPenalty ? 0.6 : 0.35; // much stronger in strictPenalty mode
+					} else if (textBlob.includes(term)) {
+						penalty += options?.strictPenalty ? 0.35 : 0.2; // stronger partial penalty in strictPenalty mode
+					}
+				}
+
+				// Apply location boost and penalty to score
+				const originalScore = hit._score || 0;
+				const boostedScore = originalScore + locationBoost - penalty;
+
+				return {
+					...hit,
+					_score: boostedScore,
+				};
+			})
+			.sort((a, b) => (b._score || 0) - (a._score || 0)) // Re-sort by boosted score
+			.slice(0, limit); // Apply final limit
 	};
 
 	const processedHits = processResultsWithLocationBoost(results.hits.hits);
@@ -615,25 +639,25 @@ export const debugElasticsearch = async () => {
 		// Check if index exists
 		const indexExists = await elasticsearch.indices.exists({ index: INDEX_NAME });
 		console.log(`Index '${INDEX_NAME}' exists:`, indexExists);
-		
+
 		if (indexExists) {
 			// Get document count
 			const count = await elasticsearch.count({ index: INDEX_NAME });
 			console.log(`Document count in '${INDEX_NAME}':`, count.count);
-			
+
 			// Get a sample document
 			const sample = await elasticsearch.search({
 				index: INDEX_NAME,
 				size: 1,
-				_source: true
+				_source: true,
 			});
 			console.log('Sample document:', JSON.stringify(sample.hits.hits[0], null, 2));
 		}
-		
+
 		return { indexExists, status: 'ok' };
-    } catch (error) {
-        const err = error as Error;
-        console.error('Elasticsearch debug error:', err);
-        return { error: err.message };
+	} catch (error) {
+		const err = error as Error;
+		console.error('Elasticsearch debug error:', err);
+		return { error: err.message };
 	}
 };

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -757,38 +757,6 @@ export async function GET(req: NextRequest) {
 				return apiResponse(fallbackContacts.slice(0, limit));
 			}
 
-			// if (contacts.length < 100) {
-			// 	const fallbackContacts = await substringSearch();
-			// 	const existingContactIds = new Set(contacts.map((contact) => contact.id));
-			// 	const uniqueFallbackContacts = fallbackContacts.filter(
-			// 		(contact) => !existingContactIds.has(contact.id)
-			// 	);
-
-			// 	contacts = [...contacts, ...uniqueFallbackContacts];
-			// }
-
-			// balanced sorting combining relevance and userContactListCount
-			// const maxUserContactListCount = Math.max(
-			// 	...contacts.map((c) => c.userContactListCount),
-			// 	1
-			// );
-
-			// contacts.sort((a, b) => {
-			// 	const aRelevance = relevanceMap.get(a.id) || 0;
-			// 	const bRelevance = relevanceMap.get(b.id) || 0;
-
-			// 	// Normalize userContactListCount (invert so lower count = higher score)
-			// 	const aCountScore = 1 - a.userContactListCount / maxUserContactListCount;
-			// 	const bCountScore = 1 - b.userContactListCount / maxUserContactListCount;
-
-			// 	// Weighted combination (70% relevance, 30% userContactListCount)
-			// 	const aCompositeScore = 0.4 * aRelevance + 0.6 * aCountScore;
-			// 	const bCompositeScore = 0.4 * bRelevance + 0.6 * bCountScore;
-
-			// 	// Sort by composite score (descending - higher score first)
-			// 	return bCompositeScore - aCompositeScore;
-			// });
-
 			return apiResponse(contacts.slice(0, limit));
 		} else {
 			// Use regular search if vector search is not enabled

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -74,18 +74,24 @@ export async function GET(req: NextRequest) {
 		if (!userId) {
 			return apiUnauthorized();
 		}
-		
+
 		// Check subscription status
 		const user = await prisma.user.findUnique({
 			where: { clerkId: userId },
-			select: { stripeSubscriptionStatus: true }
+			select: { stripeSubscriptionStatus: true },
 		});
-		
+
 		// Allow both active subscriptions and free trials
-		if (!user || (user.stripeSubscriptionStatus !== 'active' && user.stripeSubscriptionStatus !== 'trialing')) {
-			return apiBadRequest('An active subscription or free trial is required to search for contacts');
+		if (
+			!user ||
+			(user.stripeSubscriptionStatus !== 'active' &&
+				user.stripeSubscriptionStatus !== 'trialing')
+		) {
+			return apiBadRequest(
+				'An active subscription or free trial is required to search for contacts'
+			);
 		}
-		
+
 		const validatedFilters = getValidatedParamsFromUrl(req.url, contactFilterSchema);
 		if (!validatedFilters.success) {
 			return apiBadRequest(validatedFilters.error);
@@ -100,13 +106,13 @@ export async function GET(req: NextRequest) {
 			excludeUsedContacts,
 		} = validatedFilters.data;
 
-        let locationResponse: string | null = null;
-        const rawQuery = query || '';
-        if (process.env.OPEN_AI_API_KEY && rawQuery) {
-            try {
-                locationResponse = await fetchOpenAi(
-                    OPEN_AI_MODEL_OPTIONS.o4mini,
-                    `You are a geography and language expert that can tell the difference between words that are city, states, or countries, and words that are not, based on knowledge about place names as well as semantics and context of a given sentence. You will be given a search query that may contain words that are city, states, or countries, amongst other non-location based terms. You will separate the location words from the rest of the query, and return the words that are city, state, or country, along with the rest of the query in a JSON string in the following format: {"city": "cityName", "state": "stateName", "country": "countryName", "restOfQuery": "restOfQuery"}. 
+		let locationResponse: string | null = null;
+		const rawQuery = query || '';
+		if (process.env.OPEN_AI_API_KEY && rawQuery) {
+			try {
+				locationResponse = await fetchOpenAi(
+					OPEN_AI_MODEL_OPTIONS.o4mini,
+					`You are a geography and language expert that can tell the difference between words that are city, states, or countries, and words that are not, based on knowledge about place names as well as semantics and context of a given sentence. You will be given a search query that may contain words that are city, states, or countries, amongst other non-location based terms. You will separate the location words from the rest of the query, and return the words that are city, state, or country, along with the rest of the query in a JSON string in the following format: {"city": "cityName", "state": "stateName", "country": "countryName", "restOfQuery": "restOfQuery"}. 
                     
                     Additional instructions:
                     - Do not include country unless it is specified.
@@ -118,41 +124,55 @@ export async function GET(req: NextRequest) {
                     - Return a valid JSON string that can be parsed by a JSON.parse() in JavaScript. 
                     - There are some place names that can also be a word (such as buffalo steak house in new york) (Buffalo is a city in New York but it is also a general word for an animal). Use the context of the query to determine if the word is a place name or not.
                     - Return the JSON string and nothing else.`,
-                    rawQuery
-                );
-            } catch (openAiError) {
-                console.error('OpenAI location parsing failed:', openAiError);
-                // Continue without location parsing if OpenAI fails
-                locationResponse = null;
-            }
-        } else if (!process.env.OPEN_AI_API_KEY) {
-            console.warn('OPEN_AI_API_KEY is not set. Location parsing will be skipped.');
-        }
+					rawQuery
+				);
+			} catch (openAiError) {
+				console.error('OpenAI location parsing failed:', openAiError);
+				// Continue without location parsing if OpenAI fails
+				locationResponse = null;
+			}
+		} else if (!process.env.OPEN_AI_API_KEY) {
+			console.warn('OPEN_AI_API_KEY is not set. Location parsing will be skipped.');
+		}
 
-        // Parse location via LLM with a fast timeout and graceful fallback or no-LLM fallback
-        let queryJson: { city: string | null; state: string | null; country: string | null; restOfQuery: string } = {
-            city: null,
-            state: null,
-            country: null,
-            restOfQuery: rawQuery
-        };
-        if (locationResponse) {
-            try {
-                const parsed = JSON.parse(stripBothSidesOfBraces(locationResponse));
-                queryJson = {
-                    city: parsed?.city ?? null,
-                    state: parsed?.state ?? null,
-                    country: parsed?.country ?? null,
-                    restOfQuery: typeof parsed?.restOfQuery === 'string' ? parsed.restOfQuery : rawQuery
-                };
-            } catch (e) {
-                console.warn('OpenAI location parsing failed, falling back to raw query.', e);
-            }
-        }
-        // Apply deterministic overrides and tuning knobs
-        const { overrides, penaltyCities, forceCityExactCity, forceStateAny, forceCityAny, penaltyTerms, strictPenalty } = applyHardcodedLocationOverrides(query || '', queryJson);
-        queryJson = overrides;
-        const effectiveLocationStrategy = queryJson?.state ? 'strict' : 'flexible';
+		// Parse location via LLM with a fast timeout and graceful fallback or no-LLM fallback
+		let queryJson: {
+			city: string | null;
+			state: string | null;
+			country: string | null;
+			restOfQuery: string;
+		} = {
+			city: null,
+			state: null,
+			country: null,
+			restOfQuery: rawQuery,
+		};
+		if (locationResponse) {
+			try {
+				const parsed = JSON.parse(stripBothSidesOfBraces(locationResponse));
+				queryJson = {
+					city: parsed?.city ?? null,
+					state: parsed?.state ?? null,
+					country: parsed?.country ?? null,
+					restOfQuery:
+						typeof parsed?.restOfQuery === 'string' ? parsed.restOfQuery : rawQuery,
+				};
+			} catch (e) {
+				console.warn('OpenAI location parsing failed, falling back to raw query.', e);
+			}
+		}
+		// Apply deterministic overrides and tuning knobs
+		const {
+			overrides,
+			penaltyCities,
+			forceCityExactCity,
+			forceStateAny,
+			forceCityAny,
+			penaltyTerms,
+			strictPenalty,
+		} = applyHardcodedLocationOverrides(query || '', queryJson);
+		queryJson = overrides;
+		const effectiveLocationStrategy = queryJson?.state ? 'strict' : 'flexible';
 
 		const numberContactListIds: number[] =
 			contactListIds?.map((id) => Number(id)).filter((id) => !isNaN(id)) || [];
@@ -178,53 +198,68 @@ export async function GET(req: NextRequest) {
 			}
 		}
 
-        const substringSearch = async (): Promise<Contact[]> => {
+		const substringSearch = async (): Promise<Contact[]> => {
 			const searchTerms: string[] =
 				query
 					?.toLowerCase()
 					.split(/\s+/)
 					.filter((term) => term.length > 0) || [];
 			const caseInsensitiveMode = 'insensitive' as const;
-            // Build location OR conditions only when parsed parts are present to satisfy Prisma types
-            const locationOr: Prisma.ContactWhereInput[] = [];
-            if (location) {
-                if (queryJson.city) {
-                    locationOr.push(
-                        { city: { contains: queryJson.city, mode: caseInsensitiveMode } },
-                        { address: { contains: queryJson.city, mode: caseInsensitiveMode } }
-                    );
-                }
-                if (queryJson.state) {
-                    locationOr.push(
-                        { state: { contains: queryJson.state, mode: caseInsensitiveMode } },
-                        { address: { contains: queryJson.state, mode: caseInsensitiveMode } }
-                    );
-                }
-                if (queryJson.country) {
-                    locationOr.push(
-                        { country: { contains: queryJson.country, mode: caseInsensitiveMode } },
-                        { address: { contains: queryJson.country, mode: caseInsensitiveMode } }
-                    );
-                }
-            }
+			// Build location OR conditions only when parsed parts are present to satisfy Prisma types
+			const locationOr: Prisma.ContactWhereInput[] = [];
+			if (location) {
+				if (queryJson.city) {
+					locationOr.push(
+						{ city: { contains: queryJson.city, mode: caseInsensitiveMode } },
+						{ address: { contains: queryJson.city, mode: caseInsensitiveMode } }
+					);
+				}
+				if (queryJson.state) {
+					locationOr.push(
+						{ state: { contains: queryJson.state, mode: caseInsensitiveMode } },
+						{ address: { contains: queryJson.state, mode: caseInsensitiveMode } }
+					);
+				}
+				if (queryJson.country) {
+					locationOr.push(
+						{ country: { contains: queryJson.country, mode: caseInsensitiveMode } },
+						{ address: { contains: queryJson.country, mode: caseInsensitiveMode } }
+					);
+				}
+			}
 
-            // If preprocessing hinted an exact city (e.g., Philadelphia strict mode), enforce strict city/state
-            const strictLocationAnd: Prisma.ContactWhereInput[] = [];
-            if (forceCityExactCity) {
-                strictLocationAnd.push({ city: { equals: forceCityExactCity, mode: caseInsensitiveMode } });
-            }
-            if ((forceCityExactCity || (forceCityAny && forceCityAny.length > 0)) && queryJson.state) {
-                if (forceStateAny && forceStateAny.length > 0) {
-                    strictLocationAnd.push({ OR: forceStateAny.map((s) => ({ state: { equals: s, mode: caseInsensitiveMode } })) });
-                } else {
-                    strictLocationAnd.push({ state: { equals: queryJson.state, mode: caseInsensitiveMode } });
-                }
-            }
-            if (forceCityAny && forceCityAny.length > 0) {
-                strictLocationAnd.push({ OR: forceCityAny.map((c) => ({ city: { equals: c, mode: caseInsensitiveMode } })) });
-            }
+			// If preprocessing hinted an exact city (e.g., Philadelphia strict mode), enforce strict city/state
+			const strictLocationAnd: Prisma.ContactWhereInput[] = [];
+			if (forceCityExactCity) {
+				strictLocationAnd.push({
+					city: { equals: forceCityExactCity, mode: caseInsensitiveMode },
+				});
+			}
+			if (
+				(forceCityExactCity || (forceCityAny && forceCityAny.length > 0)) &&
+				queryJson.state
+			) {
+				if (forceStateAny && forceStateAny.length > 0) {
+					strictLocationAnd.push({
+						OR: forceStateAny.map((s) => ({
+							state: { equals: s, mode: caseInsensitiveMode },
+						})),
+					});
+				} else {
+					strictLocationAnd.push({
+						state: { equals: queryJson.state, mode: caseInsensitiveMode },
+					});
+				}
+			}
+			if (forceCityAny && forceCityAny.length > 0) {
+				strictLocationAnd.push({
+					OR: forceCityAny.map((c) => ({
+						city: { equals: c, mode: caseInsensitiveMode },
+					})),
+				});
+			}
 
-            const whereConditions: Prisma.ContactWhereInput = {
+			const whereConditions: Prisma.ContactWhereInput = {
 				AND: [
 					// Search terms condition (only if there are search terms)
 					...(searchTerms.length > 0
@@ -254,10 +289,10 @@ export async function GET(req: NextRequest) {
 					...(verificationStatus
 						? [{ emailValidationStatus: { equals: verificationStatus } }]
 						: []),
-                    // Location condition (must match at least one location field)
-                    ...(location && locationOr.length > 0 ? [{ OR: locationOr }] : []),
-                    // Strict city/state enforcement when we have forceCityExactCity from preprocessing (e.g., Philadelphia)
-                    ...(strictLocationAnd.length > 0 ? strictLocationAnd : []),
+					// Location condition (must match at least one location field)
+					...(location && locationOr.length > 0 ? [{ OR: locationOr }] : []),
+					// Strict city/state enforcement when we have forceCityExactCity from preprocessing (e.g., Philadelphia)
+					...(strictLocationAnd.length > 0 ? strictLocationAnd : []),
 					// Exclude used contacts condition
 					...(excludeUsedContacts && addedContactIds.length > 0
 						? [{ id: { notIn: addedContactIds } }]
@@ -265,13 +300,13 @@ export async function GET(req: NextRequest) {
 				],
 			};
 
-            // Overshoot take for venue-like queries so we can fill tail with aux (bars/restaurants)
-            const requestedLimit = limit ?? VECTOR_SEARCH_LIMIT_DEFAULT;
-            const effectiveTake = requestedLimit;
+			// Overshoot take for venue-like queries so we can fill tail with aux (bars/restaurants)
+			const requestedLimit = limit ?? VECTOR_SEARCH_LIMIT_DEFAULT;
+			const effectiveTake = requestedLimit;
 
-            return await prisma.contact.findMany({
+			return await prisma.contact.findMany({
 				where: whereConditions,
-                take: effectiveTake,
+				take: effectiveTake,
 				orderBy: {
 					userContactListCount: 'asc',
 				},
@@ -300,159 +335,184 @@ export async function GET(req: NextRequest) {
 			return apiResponse(contacts);
 		}
 
-		        // If vector search is enabled and we have a query, use vector search
-        if (useVectorSearch && query) {
-            // Determine if this is a venue-like query that uses positive signals; overshoot to allow a lenient tail
-            let postTrainingProfile;
-            try {
-                postTrainingProfile = await getPostTrainingForQuery(query || '');
-            } catch (error) {
-                console.error('Error getting post training profile:', error);
-                postTrainingProfile = { active: false, excludeTerms: [], demoteTerms: [] };
-            }
-            const requestedLimit = Math.max(1, Math.min(limit ?? VECTOR_SEARCH_LIMIT_DEFAULT, 200));
-            const effectiveVectorLimit = postTrainingProfile.requirePositive
-                ? Math.min(Math.max(requestedLimit + 20, Math.ceil(requestedLimit * 1.2)), 200)
-                : requestedLimit;
-            // Protect the vector path with a timeout and fallback to substring search
-            const vectorSearchWithTimeout = async () => {
-                const timeoutMs = 14000; // keep the UI snappy
-                return await Promise.race([
-                    searchSimilarContacts(
-                        queryJson,
-                        effectiveVectorLimit,
-                        0.1,
-                        effectiveLocationStrategy,
-                        { penaltyCities, forceCityExactCity, forceStateAny, forceCityAny, penaltyTerms, strictPenalty }
-                    ),
-                    new Promise<never>((_, reject) =>
-                        setTimeout(() => reject(new Error('Vector search timed out')), timeoutMs)
-                    ),
-                ]);
-            };
+		// If vector search is enabled and we have a query, use vector search
+		if (useVectorSearch && query) {
+			// Determine if this is a venue-like query that uses positive signals; overshoot to allow a lenient tail
+			let postTrainingProfile;
+			try {
+				postTrainingProfile = await getPostTrainingForQuery(query || '');
+			} catch (error) {
+				console.error('Error getting post training profile:', error);
+				postTrainingProfile = { active: false, excludeTerms: [], demoteTerms: [] };
+			}
+			const requestedLimit = Math.max(
+				1,
+				Math.min(limit ?? VECTOR_SEARCH_LIMIT_DEFAULT, 200)
+			);
+			const effectiveVectorLimit = postTrainingProfile.requirePositive
+				? Math.min(Math.max(requestedLimit + 20, Math.ceil(requestedLimit * 1.2)), 200)
+				: requestedLimit;
+			// Protect the vector path with a timeout and fallback to substring search
+			const vectorSearchWithTimeout = async () => {
+				const timeoutMs = 14000; // keep the UI snappy
+				return await Promise.race([
+					searchSimilarContacts(
+						queryJson,
+						effectiveVectorLimit,
+						0.1,
+						effectiveLocationStrategy,
+						{
+							penaltyCities,
+							forceCityExactCity,
+							forceStateAny,
+							forceCityAny,
+							penaltyTerms,
+							strictPenalty,
+						}
+					),
+					new Promise<never>((_, reject) =>
+						setTimeout(() => reject(new Error('Vector search timed out')), timeoutMs)
+					),
+				]);
+			};
 
-            let vectorSearchResults;
-            try {
-                vectorSearchResults = await vectorSearchWithTimeout();
-            } catch (e) {
-                console.warn('Vector search timed out or failed, falling back to substring search.', e);
-                const fallback = await substringSearch();
-                return apiResponse(fallback);
-            }
-            // Pre-filter ES matches using post-training to remove academic institutions early,
-            // but allow a lenient tail to fill close-to-limit venue searches
-            const prePostProfile = postTrainingProfile;
-            let esMatches = vectorSearchResults.matches;
-            if (prePostProfile.active && esMatches.length > 0) {
-                type EsMatch = { id: string; score: number; metadata: Record<string, unknown> };
-                const excludeTerms = prePostProfile.excludeTerms.map((t) => t.toLowerCase());
-                const includeCompany = (prePostProfile.includeCompanyTerms || []).map((t) => t.toLowerCase());
-                const includeTitle = (prePostProfile.includeTitleTerms || []).map((t) => t.toLowerCase());
-                const includeWebsite = (prePostProfile.includeWebsiteTerms || []).map((t) => t.toLowerCase());
-                const includeIndustry = (prePostProfile.includeIndustryTerms || []).map((t) => t.toLowerCase());
-                const auxCompany = (prePostProfile.auxCompanyTerms || []).map((t) => t.toLowerCase());
-                const auxTitle = (prePostProfile.auxTitleTerms || []).map((t) => t.toLowerCase());
-                const auxWebsite = (prePostProfile.auxWebsiteTerms || []).map((t) => t.toLowerCase());
-                const auxIndustry = (prePostProfile.auxIndustryTerms || []).map((t) => t.toLowerCase());
-                const containsAny = (text: string | null | undefined, terms: string[]) => {
-                    if (!text) return false;
-                    const lc = String(text).toLowerCase();
-                    return terms.some((t) => lc.includes(t));
-                };
-                const metaValue = (md: Record<string, unknown> | undefined, key: string): string | null => {
-                    if (!md) return null;
-                    const value = (md as Record<string, unknown>)[key];
-                    if (value == null) return null;
-                    if (typeof value === 'string') return value;
-                    if (Array.isArray(value)) {
-                        const first = value[0] as unknown;
-                        return first == null ? null : String(first);
-                    }
-                    return String(value);
-                };
-                const passesPositive = (md: Record<string, unknown>) => {
-                    if (!prePostProfile.requirePositive) return true;
-                    return (
-                        containsAny(metaValue(md, 'company'), includeCompany) ||
-                        containsAny(metaValue(md, 'title'), includeTitle) ||
-                        containsAny(metaValue(md, 'headline'), [...includeCompany, ...includeTitle]) ||
-                        containsAny(metaValue(md, 'website'), includeWebsite) ||
-                        containsAny(metaValue(md, 'companyIndustry'), includeIndustry) ||
-                        containsAny(metaValue(md, 'metadata'), [...includeCompany, ...includeTitle])
-                    );
-                };
-                const passesAux = (md: Record<string, unknown>) => {
-                    // Lower-priority inclusions to fill tail (e.g., bars/restaurants)
-                    return (
-                        containsAny(metaValue(md, 'company'), auxCompany) ||
-                        containsAny(metaValue(md, 'title'), auxTitle) ||
-                        containsAny(metaValue(md, 'headline'), [...auxCompany, ...auxTitle]) ||
-                        containsAny(metaValue(md, 'website'), auxWebsite) ||
-                        containsAny(metaValue(md, 'companyIndustry'), auxIndustry) ||
-                        containsAny(metaValue(md, 'metadata'), [...auxCompany, ...auxTitle])
-                    );
-                };
+			let vectorSearchResults;
+			try {
+				vectorSearchResults = await vectorSearchWithTimeout();
+			} catch (e) {
+				console.warn(
+					'Vector search timed out or failed, falling back to substring search.',
+					e
+				);
+				const fallback = await substringSearch();
+				return apiResponse(fallback);
+			}
+			// Pre-filter ES matches using post-training to remove academic institutions early,
+			// but allow a lenient tail to fill close-to-limit venue searches
+			const prePostProfile = postTrainingProfile;
+			let esMatches = vectorSearchResults.matches;
+			if (prePostProfile.active && esMatches.length > 0) {
+				type EsMatch = { id: string; score: number; metadata: Record<string, unknown> };
+				const excludeTerms = prePostProfile.excludeTerms.map((t) => t.toLowerCase());
+				const includeCompany = (prePostProfile.includeCompanyTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const includeTitle = (prePostProfile.includeTitleTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const includeWebsite = (prePostProfile.includeWebsiteTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const includeIndustry = (prePostProfile.includeIndustryTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const auxCompany = (prePostProfile.auxCompanyTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const auxTitle = (prePostProfile.auxTitleTerms || []).map((t) => t.toLowerCase());
+				const auxWebsite = (prePostProfile.auxWebsiteTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const auxIndustry = (prePostProfile.auxIndustryTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const containsAny = (text: string | null | undefined, terms: string[]) => {
+					if (!text) return false;
+					const lc = String(text).toLowerCase();
+					return terms.some((t) => lc.includes(t));
+				};
+				const metaValue = (
+					md: Record<string, unknown> | undefined,
+					key: string
+				): string | null => {
+					if (!md) return null;
+					const value = (md as Record<string, unknown>)[key];
+					if (value == null) return null;
+					if (typeof value === 'string') return value;
+					if (Array.isArray(value)) {
+						const first = value[0] as unknown;
+						return first == null ? null : String(first);
+					}
+					return String(value);
+				};
+				const passesPositive = (md: Record<string, unknown>) => {
+					if (!prePostProfile.requirePositive) return true;
+					return (
+						containsAny(metaValue(md, 'company'), includeCompany) ||
+						containsAny(metaValue(md, 'title'), includeTitle) ||
+						containsAny(metaValue(md, 'headline'), [
+							...includeCompany,
+							...includeTitle,
+						]) ||
+						containsAny(metaValue(md, 'website'), includeWebsite) ||
+						containsAny(metaValue(md, 'companyIndustry'), includeIndustry) ||
+						containsAny(metaValue(md, 'metadata'), [...includeCompany, ...includeTitle])
+					);
+				};
+				const passesAux = (md: Record<string, unknown>) => {
+					// Lower-priority inclusions to fill tail (e.g., bars/restaurants)
+					return (
+						containsAny(metaValue(md, 'company'), auxCompany) ||
+						containsAny(metaValue(md, 'title'), auxTitle) ||
+						containsAny(metaValue(md, 'headline'), [...auxCompany, ...auxTitle]) ||
+						containsAny(metaValue(md, 'website'), auxWebsite) ||
+						containsAny(metaValue(md, 'companyIndustry'), auxIndustry) ||
+						containsAny(metaValue(md, 'metadata'), [...auxCompany, ...auxTitle])
+					);
+				};
 
-                // Always enforce hard excludes first
-                const strictlyAllowed = esMatches.filter((m) => {
-                    const md: Record<string, unknown> = m.metadata || {};
-                    return !(
-                        containsAny(md.company as string | null, excludeTerms) ||
-                        containsAny(md.title as string | null, excludeTerms) ||
-                        containsAny(md.headline as string | null, excludeTerms)
-                    );
-                });
+				// Always enforce hard excludes first
+				const strictlyAllowed = esMatches.filter((m) => {
+					const md: Record<string, unknown> = m.metadata || {};
+					return !(
+						containsAny(md.company as string | null, excludeTerms) ||
+						containsAny(md.title as string | null, excludeTerms) ||
+						containsAny(md.headline as string | null, excludeTerms)
+					);
+				});
 
-                // Require positives for primary set when configured, then prefer aux (bars/restaurants) for tail fill
-                const strictlyAllowedTyped = strictlyAllowed as unknown as EsMatch[];
-                const positivesOnly = prePostProfile.requirePositive
-                    ? strictlyAllowedTyped.filter((m) => passesPositive(m.metadata || {}))
-                    : strictlyAllowed;
+				// Require positives for primary set when configured, then prefer aux (bars/restaurants) for tail fill
+				const strictlyAllowedTyped = strictlyAllowed as unknown as EsMatch[];
+				const positivesOnly = prePostProfile.requirePositive
+					? strictlyAllowedTyped.filter((m) => passesPositive(m.metadata || {}))
+					: strictlyAllowed;
 
-                const finalLimit = limit ?? VECTOR_SEARCH_LIMIT_DEFAULT;
+				const finalLimit = limit ?? VECTOR_SEARCH_LIMIT_DEFAULT;
 
-                if (prePostProfile.requirePositive) {
-                    // Prioritize: positives -> aux -> remaining non-excluded
-                    const seen = new Set<string>();
-                    const keyOf = (m: EsMatch) => String(((m.metadata as Record<string, unknown>)['contactId']) || m.id || '');
-                    const ordered: EsMatch[] = [];
-                    const pushIfNew = (m: EsMatch) => {
-                        const k = keyOf(m);
-                        if (!k || seen.has(k)) return false;
-                        seen.add(k);
-                        ordered.push(m);
-                        return true;
-                    };
+				if (prePostProfile.requirePositive) {
+					// Prioritize: positives -> aux -> remaining non-excluded
+					const seen = new Set<string>();
+					const keyOf = (m: EsMatch) =>
+						String((m.metadata as Record<string, unknown>)['contactId'] || m.id || '');
+					const ordered: EsMatch[] = [];
+					const pushIfNew = (m: EsMatch) => {
+						const k = keyOf(m);
+						if (!k || seen.has(k)) return false;
+						seen.add(k);
+						ordered.push(m);
+						return true;
+					};
 
-                    for (const m of (positivesOnly as unknown as EsMatch[])) pushIfNew(m);
-                    for (const m of strictlyAllowedTyped) {
-                        if (!passesPositive(m.metadata || {}) && passesAux(m.metadata || {})) pushIfNew(m);
-                        if (ordered.length >= finalLimit) break;
-                    }
-                    if (ordered.length < finalLimit) {
-                        for (const m of strictlyAllowedTyped) {
-                            if (!passesPositive(m.metadata || {}) && !passesAux(m.metadata || {})) pushIfNew(m);
-                            if (ordered.length >= finalLimit) break;
-                        }
-                    }
-                    esMatches = (ordered.slice(0, finalLimit) as unknown) as typeof esMatches;
-                } else {
-                    esMatches = (positivesOnly.slice(0, finalLimit) as unknown) as typeof esMatches;
-                }
-            }
-			// 8.1 seemed like a good limit to keep noise out of music venues...but restrictive for
+					for (const m of positivesOnly as unknown as EsMatch[]) pushIfNew(m);
+					for (const m of strictlyAllowedTyped) {
+						if (!passesPositive(m.metadata || {}) && passesAux(m.metadata || {}))
+							pushIfNew(m);
+						if (ordered.length >= finalLimit) break;
+					}
+					if (ordered.length < finalLimit) {
+						for (const m of strictlyAllowedTyped) {
+							if (!passesPositive(m.metadata || {}) && !passesAux(m.metadata || {}))
+								pushIfNew(m);
+							if (ordered.length >= finalLimit) break;
+						}
+					}
+					esMatches = ordered.slice(0, finalLimit) as unknown as typeof esMatches;
+				} else {
+					esMatches = positivesOnly.slice(0, finalLimit) as unknown as typeof esMatches;
+				}
+			}
 
-			// Create a map of contactId to relevance score for efficient lookup
-			// const relevanceMap = new Map<number, number>();
-			// vectorSearchResults.matches.forEach((match, index) => {
-			// 	const contactId = Number((match.metadata as { contactId: number }).contactId);
-			// 	// Use the actual score from vector search, or fall back to rank-based scoring
-			// 	const relevanceScore =
-			// 		match.score || 1 - index / vectorSearchResults.matches.length;
-			// 	relevanceMap.set(contactId, relevanceScore);
-			// });
-
-            const vectorSearchContactIds = esMatches
+			const vectorSearchContactIds = esMatches
 				.map((match) => Number(match.metadata.contactId ?? match.id))
 				.filter((n) => Number.isFinite(n));
 
@@ -460,7 +520,7 @@ export async function GET(req: NextRequest) {
 			// 	(match) => match.metadata.email
 			// ); // for testing production data locally
 
-            contacts = await prisma.contact.findMany({
+			contacts = await prisma.contact.findMany({
 				where: {
 					id: {
 						in: vectorSearchContactIds,
@@ -477,133 +537,164 @@ export async function GET(req: NextRequest) {
 				},
 			});
 
-            // Defensive strict-location enforcement for vector results
-            if ((forceCityExactCity || (forceCityAny && forceCityAny.length > 0)) && (queryJson.state || forceStateAny)) {
-                const allowedStates = forceStateAny && forceStateAny.length > 0
-                    ? new Set(forceStateAny.map((s) => s.toLowerCase()))
-                    : (queryJson.state ? new Set([queryJson.state.toLowerCase()]) : new Set<string>());
-                const targetCities = forceCityAny && forceCityAny.length > 0 ? new Set(forceCityAny.map((c) => c.toLowerCase())) : (forceCityExactCity ? new Set([forceCityExactCity.toLowerCase()]) : new Set<string>());
-                contacts = contacts.filter((c) => {
-                    const cityVal = (c.city || '').toLowerCase();
-                    const cityOk = targetCities.size === 0 ? true : targetCities.has(cityVal);
-                    const stateVal = (c.state || '').toLowerCase();
-                    const stateOk = allowedStates.size === 0 ? true : allowedStates.has(stateVal);
-                    return cityOk && stateOk;
-                });
-            }
+			// Defensive strict-location enforcement for vector results
+			if (
+				(forceCityExactCity || (forceCityAny && forceCityAny.length > 0)) &&
+				(queryJson.state || forceStateAny)
+			) {
+				const allowedStates =
+					forceStateAny && forceStateAny.length > 0
+						? new Set(forceStateAny.map((s) => s.toLowerCase()))
+						: queryJson.state
+						? new Set([queryJson.state.toLowerCase()])
+						: new Set<string>();
+				const targetCities =
+					forceCityAny && forceCityAny.length > 0
+						? new Set(forceCityAny.map((c) => c.toLowerCase()))
+						: forceCityExactCity
+						? new Set([forceCityExactCity.toLowerCase()])
+						: new Set<string>();
+				contacts = contacts.filter((c) => {
+					const cityVal = (c.city || '').toLowerCase();
+					const cityOk = targetCities.size === 0 ? true : targetCities.has(cityVal);
+					const stateVal = (c.state || '').toLowerCase();
+					const stateOk = allowedStates.size === 0 ? true : allowedStates.has(stateVal);
+					return cityOk && stateOk;
+				});
+			}
 
-            // Posttraining step: exclude or demote universities for music venue searches
-            let postProfile;
-            try {
-                postProfile = await getPostTrainingForQuery(query || '');
-            } catch (error) {
-                console.error('Error getting post training profile for filtering:', error);
-                postProfile = { active: false, excludeTerms: [], demoteTerms: [] };
-            }
-            if (postProfile.active && contacts.length > 0) {
-                const excludeTerms = postProfile.excludeTerms.map((t) => t.toLowerCase());
-                const demoteTerms = postProfile.demoteTerms.map((t) => t.toLowerCase());
-                const includeCompany = (postProfile.includeCompanyTerms || []).map((t) => t.toLowerCase());
-                const includeTitle = (postProfile.includeTitleTerms || []).map((t) => t.toLowerCase());
-                const includeWebsite = (postProfile.includeWebsiteTerms || []).map((t) => t.toLowerCase());
-                const includeIndustry = (postProfile.includeIndustryTerms || []).map((t) => t.toLowerCase());
-                const auxCompany = (postProfile.auxCompanyTerms || []).map((t) => t.toLowerCase());
-                const auxTitle = (postProfile.auxTitleTerms || []).map((t) => t.toLowerCase());
-                const auxWebsite = (postProfile.auxWebsiteTerms || []).map((t) => t.toLowerCase());
-                const auxIndustry = (postProfile.auxIndustryTerms || []).map((t) => t.toLowerCase());
+			// Posttraining step: exclude or demote universities for music venue searches
+			let postProfile;
+			try {
+				postProfile = await getPostTrainingForQuery(query || '');
+			} catch (error) {
+				console.error('Error getting post training profile for filtering:', error);
+				postProfile = { active: false, excludeTerms: [], demoteTerms: [] };
+			}
+			if (postProfile.active && contacts.length > 0) {
+				const excludeTerms = postProfile.excludeTerms.map((t) => t.toLowerCase());
+				const demoteTerms = postProfile.demoteTerms.map((t) => t.toLowerCase());
+				const includeCompany = (postProfile.includeCompanyTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const includeTitle = (postProfile.includeTitleTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const includeWebsite = (postProfile.includeWebsiteTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const includeIndustry = (postProfile.includeIndustryTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const auxCompany = (postProfile.auxCompanyTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const auxTitle = (postProfile.auxTitleTerms || []).map((t) => t.toLowerCase());
+				const auxWebsite = (postProfile.auxWebsiteTerms || []).map((t) =>
+					t.toLowerCase()
+				);
+				const auxIndustry = (postProfile.auxIndustryTerms || []).map((t) =>
+					t.toLowerCase()
+				);
 
-                const containsAny = (text: string | null | undefined, terms: string[]) => {
-                    if (!text) return false;
-                    const lc = text.toLowerCase();
-                    return terms.some((t) => lc.includes(t));
-                };
-                const passesPositive = (c: Contact) => {
-                    if (!postProfile.requirePositive) return true;
-                    return (
-                        containsAny(c.company, includeCompany) ||
-                        containsAny(c.title, includeTitle) ||
-                        containsAny(c.headline, [...includeCompany, ...includeTitle]) ||
-                        containsAny(c.website, includeWebsite) ||
-                        containsAny(c.companyIndustry, includeIndustry) ||
-                        containsAny(c.metadata, [...includeCompany, ...includeTitle])
-                    );
-                };
-                const passesAux = (c: Contact) => {
-                    return (
-                        containsAny(c.company, auxCompany) ||
-                        containsAny(c.title, auxTitle) ||
-                        containsAny(c.headline, [...auxCompany, ...auxTitle]) ||
-                        containsAny(c.website, auxWebsite) ||
-                        containsAny(c.companyIndustry, auxIndustry) ||
-                        containsAny(c.metadata, [...auxCompany, ...auxTitle])
-                    );
-                };
+				const containsAny = (text: string | null | undefined, terms: string[]) => {
+					if (!text) return false;
+					const lc = text.toLowerCase();
+					return terms.some((t) => lc.includes(t));
+				};
+				const passesPositive = (c: Contact) => {
+					if (!postProfile.requirePositive) return true;
+					return (
+						containsAny(c.company, includeCompany) ||
+						containsAny(c.title, includeTitle) ||
+						containsAny(c.headline, [...includeCompany, ...includeTitle]) ||
+						containsAny(c.website, includeWebsite) ||
+						containsAny(c.companyIndustry, includeIndustry) ||
+						containsAny(c.metadata, [...includeCompany, ...includeTitle])
+					);
+				};
+				const passesAux = (c: Contact) => {
+					return (
+						containsAny(c.company, auxCompany) ||
+						containsAny(c.title, auxTitle) ||
+						containsAny(c.headline, [...auxCompany, ...auxTitle]) ||
+						containsAny(c.website, auxWebsite) ||
+						containsAny(c.companyIndustry, auxIndustry) ||
+						containsAny(c.metadata, [...auxCompany, ...auxTitle])
+					);
+				};
 
-                // Exclude (hard if strictExclude=true), then require positive signals if configured
-                const strictlyAllowed = postProfile.strictExclude
-                    ? contacts.filter(
-                          (c) =>
-                              !containsAny(c.company, excludeTerms) &&
-                              !containsAny(c.title, excludeTerms) &&
-                              !containsAny(c.headline, excludeTerms)
-                      )
-                    : contacts;
+				// Exclude (hard if strictExclude=true), then require positive signals if configured
+				const strictlyAllowed = postProfile.strictExclude
+					? contacts.filter(
+							(c) =>
+								!containsAny(c.company, excludeTerms) &&
+								!containsAny(c.title, excludeTerms) &&
+								!containsAny(c.headline, excludeTerms)
+					  )
+					: contacts;
 
-                let filtered = postProfile.requirePositive
-                    ? strictlyAllowed.filter(passesPositive)
-                    : strictlyAllowed;
+				let filtered = postProfile.requirePositive
+					? strictlyAllowed.filter(passesPositive)
+					: strictlyAllowed;
 
-                // If exclusion removed too many (e.g., fewer than limit), fill with demoted ones first;
-                // when near the cap, allow a lenient tail of non-excluded items even without positives
-                const finalLimit = limit ?? VECTOR_SEARCH_LIMIT_DEFAULT;
-                if (filtered.length < finalLimit) {
-                    // Prefer demoted positives first
-                        const demotedPositives = strictlyAllowed.filter(
-                        (c) =>
-                            (containsAny(c.company, demoteTerms) ||
-                                containsAny(c.title, demoteTerms) ||
-                                containsAny(c.headline, demoteTerms)) &&
-                            (!postProfile.requirePositive || passesPositive(c))
-                    );
+				// If exclusion removed too many (e.g., fewer than limit), fill with demoted ones first;
+				// when near the cap, allow a lenient tail of non-excluded items even without positives
+				const finalLimit = limit ?? VECTOR_SEARCH_LIMIT_DEFAULT;
+				if (filtered.length < finalLimit) {
+					// Prefer demoted positives first
+					const demotedPositives = strictlyAllowed.filter(
+						(c) =>
+							(containsAny(c.company, demoteTerms) ||
+								containsAny(c.title, demoteTerms) ||
+								containsAny(c.headline, demoteTerms)) &&
+							(!postProfile.requirePositive || passesPositive(c))
+					);
 
-                    const existingIds = new Set(filtered.map((c) => c.id));
-                    const filler: Contact[] = [];
-                    for (const c of demotedPositives) {
-                        if (existingIds.has(c.id)) continue;
-                        filler.push(c);
-                        existingIds.add(c.id);
-                        if (filtered.length + filler.length >= finalLimit) break;
-                    }
+					const existingIds = new Set(filtered.map((c) => c.id));
+					const filler: Contact[] = [];
+					for (const c of demotedPositives) {
+						if (existingIds.has(c.id)) continue;
+						filler.push(c);
+						existingIds.add(c.id);
+						if (filtered.length + filler.length >= finalLimit) break;
+					}
 
-                    // If still short and we're requiring positives, prioritize AUX (bars/restaurants)
-                    if (postProfile.requirePositive && filtered.length + filler.length < finalLimit) {
-                        for (const c of strictlyAllowed) {
-                            if (existingIds.has(c.id)) continue;
-                            if (!passesPositive(c) && passesAux(c)) {
-                                filler.push(c);
-                                existingIds.add(c.id);
-                                if (filtered.length + filler.length >= finalLimit) break;
-                            }
-                        }
-                    }
+					// If still short and we're requiring positives, prioritize AUX (bars/restaurants)
+					if (
+						postProfile.requirePositive &&
+						filtered.length + filler.length < finalLimit
+					) {
+						for (const c of strictlyAllowed) {
+							if (existingIds.has(c.id)) continue;
+							if (!passesPositive(c) && passesAux(c)) {
+								filler.push(c);
+								existingIds.add(c.id);
+								if (filtered.length + filler.length >= finalLimit) break;
+							}
+						}
+					}
 
-                    // Finally, fill with remaining non-excluded if still short
-                    if (postProfile.requirePositive && filtered.length + filler.length < finalLimit) {
-                        for (const c of strictlyAllowed) {
-                            if (existingIds.has(c.id)) continue;
-                            if (!passesPositive(c) && !passesAux(c)) {
-                                filler.push(c);
-                                existingIds.add(c.id);
-                                if (filtered.length + filler.length >= finalLimit) break;
-                            }
-                        }
-                    }
+					// Finally, fill with remaining non-excluded if still short
+					if (
+						postProfile.requirePositive &&
+						filtered.length + filler.length < finalLimit
+					) {
+						for (const c of strictlyAllowed) {
+							if (existingIds.has(c.id)) continue;
+							if (!passesPositive(c) && !passesAux(c)) {
+								filler.push(c);
+								existingIds.add(c.id);
+								if (filtered.length + filler.length >= finalLimit) break;
+							}
+						}
+					}
 
-                    filtered = [...filtered, ...filler].slice(0, finalLimit);
-                }
+					filtered = [...filtered, ...filler].slice(0, finalLimit);
+				}
 
-                contacts = filtered;
-            }
+				contacts = filtered;
+			}
 
 			// Fallback: if local Postgres doesn't have these contacts, return minimal data from Elasticsearch directly
 			if (!contacts || contacts.length === 0) {
@@ -621,7 +712,9 @@ export async function GET(req: NextRequest) {
 							: [];
 
 					return {
-						id: Number.isFinite(parsedId) ? parsedId : Math.floor(Math.random() * 1_000_000_000),
+						id: Number.isFinite(parsedId)
+							? parsedId
+							: Math.floor(Math.random() * 1_000_000_000),
 						apolloPersonId: null,
 						firstName: md.firstName ?? null,
 						lastName: md.lastName ?? null,

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -354,12 +354,11 @@ export async function GET(req: NextRequest) {
 				: requestedLimit;
 			// Protect the vector path with a timeout and fallback to substring search
 			const vectorSearchWithTimeout = async () => {
-				const timeoutMs = 14000; // keep the UI snappy
+				const timeoutMs = 14000;
 				return await Promise.race([
 					searchSimilarContacts(
 						queryJson,
 						effectiveVectorLimit,
-						0.1,
 						effectiveLocationStrategy,
 						{
 							penaltyCities,

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -16,6 +16,7 @@ import { applyHardcodedLocationOverrides } from '@/app/api/_utils/searchPreproce
 import { Contact, EmailVerificationStatus, Prisma } from '@prisma/client';
 import { searchSimilarContacts, upsertContactToVectorDb } from '../_utils/vectorDb';
 import { OPEN_AI_MODEL_OPTIONS } from '@/constants';
+import { StripeSubscriptionStatus } from '@/types';
 
 const VECTOR_SEARCH_LIMIT_DEFAULT = 50;
 
@@ -84,8 +85,8 @@ export async function GET(req: NextRequest) {
 		// Allow both active subscriptions and free trials
 		if (
 			!user ||
-			(user.stripeSubscriptionStatus !== 'active' &&
-				user.stripeSubscriptionStatus !== 'trialing')
+			(user.stripeSubscriptionStatus !== StripeSubscriptionStatus.ACTIVE &&
+				user.stripeSubscriptionStatus !== StripeSubscriptionStatus.TRIALING)
 		) {
 			return apiBadRequest(
 				'An active subscription or free trial is required to search for contacts'

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -3,11 +3,10 @@ import prisma from '@/lib/prisma';
 import { z } from 'zod';
 import { auth } from '@clerk/nextjs/server';
 import {
-    apiBadRequest,
-    apiResponse,
-    apiUnauthorized,
-    apiNotFound,
-    handleApiError,
+	apiBadRequest,
+	apiResponse,
+	apiUnauthorized,
+	handleApiError,
 } from '@/app/api/_utils';
 import { ApiRouteParams } from '@/types';
 import { NextRequest } from 'next/server';
@@ -24,6 +23,7 @@ const patchUserSchema = z.object({
 	customDomain: z.string().optional().nullable(),
 	draftCredits: z.number().optional(),
 	sendingCredits: z.number().optional(),
+
 	verificationCredits: z.number().optional(),
 });
 export type PatchUserData = z.infer<typeof patchUserSchema>;
@@ -38,25 +38,11 @@ export const GET = async function GET(
 			return apiUnauthorized();
 		}
 
-        const { id } = await params;
+		const { id } = await params;
 
-        let user = await prisma.user.findUnique({ where: { clerkId: id } });
+		const user = await prisma.user.findUniqueOrThrow({ where: { clerkId: id } });
 
-        if (!user) {
-            if (process.env.NODE_ENV !== 'production') {
-                // Auto-create a minimal local user record in development
-                user = await prisma.user.create({
-                    data: {
-                        clerkId: id,
-                        email: `${id}@local.dev`,
-                    },
-                });
-            } else {
-                return apiNotFound('User not found');
-            }
-        }
-
-        return apiResponse(user);
+		return apiResponse(user);
 	} catch (error) {
 		return handleApiError(error);
 	}

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,4 +1,3 @@
-// import { User } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { z } from 'zod';
 import { auth } from '@clerk/nextjs/server';
@@ -23,7 +22,6 @@ const patchUserSchema = z.object({
 	customDomain: z.string().optional().nullable(),
 	draftCredits: z.number().optional(),
 	sendingCredits: z.number().optional(),
-
 	verificationCredits: z.number().optional(),
 });
 export type PatchUserData = z.infer<typeof patchUserSchema>;

--- a/src/app/api/vector-search/generate-embeddings/route.ts
+++ b/src/app/api/vector-search/generate-embeddings/route.ts
@@ -4,7 +4,6 @@ import { apiResponse, apiUnauthorized } from '@/app/api/_utils';
 import { initializeVectorDb, upsertContactToVectorDb } from '../../_utils/vectorDb';
 import { EmailVerificationStatus, UserRole } from '@prisma/client';
 
-// Add timeout wrapper
 const withTimeout = <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
 	return Promise.race([
 		promise,
@@ -21,7 +20,6 @@ export async function GET() {
 			return apiUnauthorized();
 		}
 
-		// Check if the user is an admin
 		const user = await prisma.user.findUnique({
 			where: {
 				clerkId: userId,
@@ -31,10 +29,8 @@ export async function GET() {
 			return apiUnauthorized();
 		}
 
-		// Add timeout to initialization
 		await withTimeout(initializeVectorDb(), 30000); // 30 second timeout
 
-		// Add timeout to database query
 		const contacts = await withTimeout(
 			prisma.contact.findMany({
 				where: {

--- a/src/app/murmur/dashboard/useDashboard.tsx
+++ b/src/app/murmur/dashboard/useDashboard.tsx
@@ -90,7 +90,6 @@ export const useDashboard = () => {
 		isPending: isPendingContacts,
 		isLoading: isLoadingContacts,
 		error,
-		refetch: refetchContacts, // eslint-disable-line @typescript-eslint/no-unused-vars
 		isRefetching: isRefetchingContacts,
 		isError,
 	} = useGetContacts({

--- a/src/components/molecules/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/molecules/VideoPlayer/VideoPlayer.tsx
@@ -35,9 +35,9 @@ export function VideoPlayer({
 					player.currentTime = 0;
 				}
 			};
-			
+
 			player.addEventListener('loadedmetadata', handleLoadedMetadata);
-			
+
 			return () => {
 				player.removeEventListener('loadedmetadata', handleLoadedMetadata);
 			};
@@ -45,12 +45,7 @@ export function VideoPlayer({
 	}, [playbackId]);
 
 	return (
-		<div
-			className={cn(
-				'w-fit h-fit aspect-video max-h-fit overflow-hidden',
-				className
-			)}
-		>
+		<div className={cn('w-fit h-fit aspect-video max-h-fit overflow-hidden', className)}>
 			<MuxPlayer
 				ref={playerRef}
 				accentColor="var(--color-primary)"
@@ -64,12 +59,10 @@ export function VideoPlayer({
 				// Disable autoplay to prevent sync issues
 				autoPlay={false}
 				// Force specific playback rates to prevent drift
-				defaultPlaybackRate={1}
 				playbackRates={[1]}
 				// Disable features that might cause sync issues
 				nohotkeys
 				// Use native controls for better sync handling
-				controls
 			/>
 		</div>
 	);

--- a/src/utils/string.tsx
+++ b/src/utils/string.tsx
@@ -1,6 +1,10 @@
 import { HybridBlockPrompt } from '@/app/murmur/campaign/[campaignId]/emailAutomation/draft/useDraftingSection';
 import { HybridBlock } from '@prisma/client';
 
+export const normalizeTextCaseAndWhitespace = (text: string): string => {
+	return text.trim().toLowerCase();
+};
+
 /**
  * Truncates text to a specified length and adds ellipses
  * Tries to break at word boundaries when possible for better readability


### PR DESCRIPTION
# General points
- When there is a type error, try to fix the error instead of using eslint-disable-next-line. There are cases when disable-next-line may be required, but they are rare. (most common in useEffect dependencies)
- functions that are used multiple times across the application, like "normalize" go in the utils folder under the appropriate category. This way, the same function does not get defined in multiple files.
- Avoid using the "any" type, find the proper type
- If you need a commonly used string value like "active" for Stripe subscription status, check if there is an enum for it. In this case, StripeSubscriptionStatus.ACTIVE provides this string value across the entire application and keeps things DRY, prevents typos.


# Changes
- Remove fake user creation, users should be created through the Clerk webhook, otherwise required data is not populated.
- Remove docker-compose deployment params, since Docker is used only for local development in our case.
- Restore former vercel-builds and local build settings
- Auto-formatting
- Extract normalize function into utils/string
- improve naming of normalize function -> normalizeTextCaseAndWhitespace
- Removed unused function, withTimeout 
- Use enum for StripeSubscriptions 
```
	(user.stripeSubscriptionStatus !== StripeSubscriptionStatus.ACTIVE &&
				user.stripeSubscriptionStatus !== StripeSubscriptionStatus.TRIALING)
```